### PR TITLE
[Setting] SwiftUI Preview utility 추가

### DIFF
--- a/Projects/App/Sources/Application/ViewController.swift
+++ b/Projects/App/Sources/Application/ViewController.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2022 zesty. All rights reserved.
 //
 
+import SwiftUI
 import UIKit
 import SnapKit
+import DesignSystem
 
 final class ViewController: UIViewController {
     
@@ -59,4 +61,12 @@ extension ViewController {
         }
     }
     
+}
+
+struct ViewControllerPreview: PreviewProvider {
+    
+    static var previews: some View {
+        ViewController().toPreview()
+    }
+
 }

--- a/Projects/App/Sources/Application/ViewControllerTemplate.swift
+++ b/Projects/App/Sources/Application/ViewControllerTemplate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 zesty. All rights reserved.
 //
 
+import SwiftUI
 import UIKit
 
 final class ViewControllerTemplate: UIViewController {
@@ -35,4 +36,14 @@ extension ViewController {
         
     }
     
+}
+
+// MARK: - Preview
+
+struct ViewControllerTemplatePreview: PreviewProvider {
+    
+    static var previews: some View {
+        ViewControllerTemplate().toPreview()
+    }
+
 }

--- a/Projects/DesignSystem/Sources/Utility/+Preview.swift
+++ b/Projects/DesignSystem/Sources/Utility/+Preview.swift
@@ -1,0 +1,76 @@
+//
+//  +Preview.swift
+//  DesignSystem
+//
+//  Created by 리아 on 2022/10/16.
+//  Copyright © 2022 zesty. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+extension UIViewController {
+
+    private struct Preview: UIViewControllerRepresentable {
+
+        let viewController: UIViewController
+
+        func makeUIViewController(context: Context) -> UIViewController {
+            return viewController
+        }
+
+        func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        }
+
+    }
+
+    /// preview를 제공하는 함수
+    ///
+    /// ```swift
+    /// struct ExViewControllerPreview: PreviewProvider {
+    ///
+    ///     static var previews: some View {
+    ///         ExViewController().toPreview()
+    ///     }
+    ///
+    /// }
+    /// ```
+
+    public func toPreview() -> some View {
+        Preview(viewController: self)
+    }
+
+}
+
+extension UIView {
+
+    private struct Preview: UIViewRepresentable {
+
+        let view: UIView
+
+        func makeUIView(context: Context) -> some UIView {
+            return view
+        }
+
+        func updateUIView(_ uiView: UIViewType, context: Context) {
+        }
+
+    }
+    
+    /// preview를 제공하는 함수
+    ///
+    /// ```swift
+    /// struct ExViewPreview: PreviewProvider {
+    ///
+    ///     static var previews: some View {
+    ///         ExView().toPreview()
+    ///     }
+    ///
+    /// }
+    /// ```
+
+    public func toPreview() -> some View {
+        Preview(view: self)
+    }
+
+}


### PR DESCRIPTION
## 작업내용
<img width="717" alt="image" src="https://user-images.githubusercontent.com/73650994/196026245-d1597c46-d87a-4588-aeb2-4ee003431e44.png">

- [x] preview 기능 추가
- [x] ViewControllerTemplate 코드에도 추가

## 리뷰포인트
- 사실 모두 알고 계신 사용방법이겠지만.. 주석으로 사용법을 추가했습니다.
일단 사용법을 documentation하였는데 오히려 거슬리면 지우겠습니다.
- 디자인시스템에서도 앱에서도 사용하게 될 것 같아서 디자인시스템에 추가하였습니다.
사용하고 싶다면 디자인시스템 모듈을 import하시면 됩니다.

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
