### PR TITLE
[Feat] 닉네임 검증 activityIndicator UI 구현

### DIFF
--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -88,13 +88,10 @@ extension NickNameInputViewController {
             }
             .store(in: &cancelBag)
         
-        nickNameTextField.textDidChangePublisher
-            .sink { [weak self] _ in
+        viewModel.$isUserReceivedWarning
+            .sink { [weak self] isUserReceivedWarning in
                 guard let self = self else { return }
-                if self.viewModel.isUserReceivedWarning {
-                    self.warningLabel.isHidden = true
-                    self.viewModel.isUserReceivedWarning = false
-                }
+                self.warningLabel.isHidden = !isUserReceivedWarning
             }
             .store(in: &cancelBag)
         
@@ -107,7 +104,6 @@ extension NickNameInputViewController {
                 self.nextButtonView.button.imageView?.isHidden = false
                 if isNickNameOverlaped {
                     self.nextButtonView.setDisabled(true)
-                    self.warningLabel.isHidden = false
                 } else {
                     self.navigationController?.pushViewController(SignupCompleteViewController(), animated: true)
                 }

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -51,7 +51,7 @@ final class NickNameInputViewController: UIViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         nickNameTextField.resignFirstResponder()
     }
-
+    
 }
 
 // MARK: - Bind Function
@@ -64,27 +64,31 @@ extension NickNameInputViewController {
             .assign(to: \.nickNameText, on: viewModel)
             .store(in: &cancelBag)
         
-        nickNameTextField.textDidBeignEditingPublisher
-            .map { _ in return true }
-            .assign(to: \.isKeyboardShown, on: viewModel)
-            .store(in: &cancelBag)
-        
-        nickNameTextField.textDidEndEditingPublisher
-            .map { _ in return false }
-            .assign(to: \.isKeyboardShown, on: viewModel)
-            .store(in: &cancelBag)
-        
         viewModel.$isTextEmpty
             .sink { [weak self] isTextEmpty in
                 self?.nextButtonView.setDisabled(isTextEmpty)
             }
             .store(in: &cancelBag)
         
-        viewModel.$isKeyboardShown
-            .sink { [weak self] isKeyboardShown in
+        NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
+            .sink { [weak self] notification in
                 guard let self = self else { return }
-                self.keyboardUpConstraints?.isActive = isKeyboardShown
-                self.keyboardDownConstraints?.isActive = !isKeyboardShown
+                if self.keyboardUpConstraints == nil {
+                    guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+                    let endFrameHeight = endFrame.cgRectValue.height
+                    self.keyboardUpConstraints =  self.nextButtonView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -endFrameHeight - 20)
+                    self.keyboardUpConstraints?.priority = .defaultLow
+                }
+                self.keyboardDownConstraints?.isActive = false
+                self.keyboardUpConstraints?.isActive = true
+            }
+            .store(in: &cancelBag)
+        
+        NotificationCenter.default.publisher(for: UIApplication.keyboardWillHideNotification)
+            .sink { [weak self ] _ in
+                guard let self = self else { return }
+                self.keyboardUpConstraints?.isActive = false
+                self.keyboardDownConstraints?.isActive = true
             }
             .store(in: &cancelBag)
         
@@ -100,7 +104,7 @@ extension NickNameInputViewController {
                 guard let self = self else { return }
                 self.nextButtonView.stopIndicator()
                 self.nextButtonView.button.setAttributedTitle(NSAttributedString(string: "다음",
-                                                              attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .bold)]), for: .normal)
+                                                                                 attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .bold)]), for: .normal)
                 self.nextButtonView.button.imageView?.isHidden = false
                 if isNickNameOverlaped {
                     self.nextButtonView.setDisabled(true)
@@ -195,11 +199,9 @@ extension NickNameInputViewController {
             make.centerX.equalTo(view.snp.centerX)
         }
         
-        keyboardUpConstraints = nextButtonView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor, constant: -20)
-        keyboardDownConstraints = nextButtonView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.bottomAnchor, constant: -100)
-        keyboardUpConstraints?.priority = .defaultLow
-        keyboardDownConstraints?.priority = .defaultLow
+        keyboardDownConstraints = nextButtonView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -100)
         keyboardDownConstraints?.isActive = true
+        keyboardDownConstraints?.priority = .defaultHigh
     }
     
 }

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -60,7 +60,7 @@ extension NickNameInputViewController {
     
     private func bindUI() {
         nickNameTextField.textDidChangePublisher
-            .compactMap { return $0.text }
+            .compactMap { $0.text }
             .assign(to: \.nickNameText, on: viewModel)
             .store(in: &cancelBag)
         

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -41,7 +41,11 @@ final class NickNameInputViewController: UIViewController {
     // MARK: - Function
     
     @objc private func nextButtonClicked() {
-        navigationController?.pushViewController(SignupCompleteViewController(), animated: true)
+        nextButtonView.startAnimating()
+        nextButtonView.button.setAttributedTitle(NSAttributedString(string: ""), for: .normal)
+        nextButtonView.button.imageView?.isHidden = true
+        
+        viewModel.checkNickNameOverlaped()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -90,6 +94,22 @@ extension NickNameInputViewController {
                 if self.viewModel.isUserReceivedWarning {
                     self.warningLabel.isHidden = true
                     self.viewModel.isUserReceivedWarning = false
+                }
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.isNickNameOverlapedSubject
+            .sink { [weak self] isNickNameOverlaped in
+                guard let self = self else { return }
+                self.nextButtonView.stopAnimating()
+                self.nextButtonView.button.setAttributedTitle(NSAttributedString(string: "다음",
+                                                              attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .bold)]), for: .normal)
+                self.nextButtonView.button.imageView?.isHidden = false
+                if isNickNameOverlaped {
+                    self.nextButtonView.setDisabled(true)
+                    self.warningLabel.isHidden = false
+                } else {
+                    self.navigationController?.pushViewController(SignupCompleteViewController(), animated: true)
                 }
             }
             .store(in: &cancelBag)

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -41,7 +41,7 @@ final class NickNameInputViewController: UIViewController {
     // MARK: - Function
     
     @objc private func nextButtonClicked() {
-        nextButtonView.activateIndicator()
+        nextButtonView.startIndicator()
         nextButtonView.button.setAttributedTitle(NSAttributedString(string: ""), for: .normal)
         nextButtonView.button.imageView?.isHidden = true
         

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -123,7 +123,9 @@ extension NickNameInputViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
-        nextButtonClicked()
+        if nextButtonView.button.isUserInteractionEnabled {
+            nextButtonClicked()
+        }
         return true
     }
     

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -88,10 +88,10 @@ extension NickNameInputViewController {
             }
             .store(in: &cancelBag)
         
-        viewModel.$isUserReceivedWarning
-            .sink { [weak self] isUserReceivedWarning in
+        viewModel.$shouldDisplayWarning
+            .sink { [weak self] shouldDisplayWarning in
                 guard let self = self else { return }
-                self.warningLabel.isHidden = !isUserReceivedWarning
+                self.warningLabel.isHidden = !shouldDisplayWarning
             }
             .store(in: &cancelBag)
         

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -76,7 +76,7 @@ extension NickNameInputViewController {
                 if self.keyboardUpConstraints == nil {
                     guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
                     let endFrameHeight = endFrame.cgRectValue.height
-                    self.keyboardUpConstraints =  self.nextButtonView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -endFrameHeight - 20)
+                    self.keyboardUpConstraints = self.nextButtonView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -endFrameHeight - 20)
                     self.keyboardUpConstraints?.priority = .defaultLow
                 }
                 self.keyboardDownConstraints?.isActive = false

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -41,7 +41,7 @@ final class NickNameInputViewController: UIViewController {
     // MARK: - Function
     
     @objc private func nextButtonClicked() {
-        nextButtonView.startAnimating()
+        nextButtonView.activateIndicator()
         nextButtonView.button.setAttributedTitle(NSAttributedString(string: ""), for: .normal)
         nextButtonView.button.imageView?.isHidden = true
         
@@ -98,7 +98,7 @@ extension NickNameInputViewController {
         viewModel.isNickNameOverlapedSubject
             .sink { [weak self] isNickNameOverlaped in
                 guard let self = self else { return }
-                self.nextButtonView.stopAnimating()
+                self.nextButtonView.stopIndicator()
                 self.nextButtonView.button.setAttributedTitle(NSAttributedString(string: "다음",
                                                               attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .bold)]), for: .normal)
                 self.nextButtonView.button.imageView?.isHidden = false

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -29,8 +29,7 @@ final class NickNameInputViewModel {
         
         $nickNameText
             .sink { [weak self] _ in
-                guard let self = self else { return }
-                if self.shouldDisplayWarning == true {
+                if let self = self, self.shouldDisplayWarning {
                     self.shouldDisplayWarning = false
                 }
             }

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -31,7 +31,8 @@ final class NickNameInputViewModel {
             .store(in: &cancelBag)
         
         $nickNameText
-            .sink { _ in
+            .sink { [weak self] _ in
+                guard let self = self else { return }
                 if self.isUserReceivedWarning {
                     self.isUserReceivedWarning = false
                 }

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -16,7 +16,7 @@ final class NickNameInputViewModel {
     
     // Output
     @Published var isTextEmpty = true
-    @Published var isUserReceivedWarning = false
+    @Published var shouldDisplayWarning = false
     let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     // Input & Output
@@ -33,8 +33,8 @@ final class NickNameInputViewModel {
         $nickNameText
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                if self.isUserReceivedWarning {
-                    self.isUserReceivedWarning = false
+                if self.shouldDisplayWarning {
+                    self.shouldDisplayWarning = false
                 }
             }
             .store(in: &cancelBag)
@@ -50,7 +50,7 @@ final class NickNameInputViewModel {
             let result = Bool.random()
             self.isNickNameOverlapedSubject.send(result)
             if result {
-                self.isUserReceivedWarning = true
+                self.shouldDisplayWarning = true
             }
         }
     }

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -33,7 +33,7 @@ final class NickNameInputViewModel {
         $nickNameText
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                if self.shouldDisplayWarning {
+                if self.shouldDisplayWarning == true {
                     self.shouldDisplayWarning = false
                 }
             }

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -16,6 +16,8 @@ final class NickNameInputViewModel {
     
     // Output
     @Published var isTextEmpty = true
+//    @Published var isNickNameOverlaped = false
+    let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     // Input & Output
     @Published var isKeyboardShown = false
@@ -33,6 +35,17 @@ final class NickNameInputViewModel {
     
     private func isEmpty(to text: String) -> Bool {
         return text.isEmpty
+    }
+    
+    func checkNickNameOverlaped() {
+        // TODO: UseCase와 통신하여 중복 체크
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            let result = Bool.random()
+            self.isNickNameOverlapedSubject.send(result)
+            if result {
+                self.isUserReceivedWarning = true
+            }
+        }
     }
     
     func isValid(for input: String) -> Bool {

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -18,9 +18,6 @@ final class NickNameInputViewModel {
     @Published var isTextEmpty = true
     @Published var shouldDisplayWarning = false
     let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
-    
-    // Input & Output
-    @Published var isKeyboardShown = false
 
     private var cancelBag = Set<AnyCancellable>()
     

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -22,6 +22,8 @@ final class NickNameInputViewModel {
 
     private var cancelBag = Set<AnyCancellable>()
     
+    var isUserReceivedWarning = false
+    
     init() {
         $nickNameText
             .map(isEmpty)

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -16,7 +16,7 @@ final class NickNameInputViewModel {
     
     // Output
     @Published var isTextEmpty = true
-//    @Published var isNickNameOverlaped = false
+    @Published var isUserReceivedWarning = false
     let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     // Input & Output
@@ -24,12 +24,18 @@ final class NickNameInputViewModel {
 
     private var cancelBag = Set<AnyCancellable>()
     
-    var isUserReceivedWarning = false
-    
     init() {
         $nickNameText
             .map(isEmpty)
             .assign(to: \.isTextEmpty, on: self)
+            .store(in: &cancelBag)
+        
+        $nickNameText
+            .sink { _ in
+                if self.isUserReceivedWarning {
+                    self.isUserReceivedWarning = false
+                }
+            }
             .store(in: &cancelBag)
     }
     

--- a/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
+++ b/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
@@ -13,6 +13,7 @@ public final class ShadowButtonView: UIView {
     
     public let button = UIButton()
     private let buttonShadowView = UIView()
+    private let activityIndicator = UIActivityIndicatorView()
     
     public init(initialDisable: Bool = false) {
         super.init(frame: .zero)
@@ -31,14 +32,27 @@ public final class ShadowButtonView: UIView {
         buttonShadowView.backgroundColor = state ? .lightGray : .black
     }
     
+    public func startAnimating() {
+        button.isUserInteractionEnabled = false
+        
+        activityIndicator.isHidden = false
+        activityIndicator.startAnimating()
+    }
+    
+    public func stopAnimating() {
+        button.isUserInteractionEnabled = true
+        
+        activityIndicator.isHidden = true
+        activityIndicator.stopAnimating()
+    }
 }
 
 extension ShadowButtonView {
     
     private func configureUI() {
-        button.tintColor = .white
+        button.tintColor = .black
         button.backgroundColor = .white
-        button.configuration = .filled()
+        button.configuration = .plain()
         button.configuration?.contentInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
         button.clipsToBounds = true
         button.layer.borderWidth = 2
@@ -47,10 +61,12 @@ extension ShadowButtonView {
         buttonShadowView.backgroundColor = .black
         buttonShadowView.clipsToBounds = true
         buttonShadowView.layer.cornerRadius = 18
+        
+        activityIndicator.isHidden = true
     }
     
     private func createLayout() {
-        addSubviews([buttonShadowView, button])
+        addSubviews([buttonShadowView, button, activityIndicator])
         
         button.snp.makeConstraints { make in
             make.leading.equalTo(snp.leading)
@@ -64,6 +80,11 @@ extension ShadowButtonView {
             make.top.equalTo(button.snp.top).offset(4)
             make.width.equalTo(button.snp.width)
             make.height.equalTo(button.snp.height)
+        }
+        
+        activityIndicator.snp.makeConstraints { make in
+            make.centerX.equalTo(snp.centerX)
+            make.centerY.equalTo(snp.centerY)
         }
     }
     

--- a/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
+++ b/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
@@ -33,7 +33,7 @@ public final class ShadowButtonView: UIView {
         buttonShadowView.backgroundColor = state ? .lightGray : .black
     }
     
-    public func activateIndicator() {
+    public func startIndicator() {
         button.isUserInteractionEnabled = false
         
         activityIndicator.isHidden = false

--- a/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
+++ b/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
@@ -27,7 +27,8 @@ public final class ShadowButtonView: UIView {
     }
     
     public func setDisabled(_ state: Bool) {
-        button.isEnabled = !state
+        button.isUserInteractionEnabled = !state
+        button.tintColor = state ? .lightGray : .black
         button.layer.borderColor = state ? UIColor.lightGray.cgColor : UIColor.black.cgColor
         buttonShadowView.backgroundColor = state ? .lightGray : .black
     }

--- a/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
+++ b/Projects/DesignSystem/Sources/Component/ShadowButtonView.swift
@@ -33,14 +33,14 @@ public final class ShadowButtonView: UIView {
         buttonShadowView.backgroundColor = state ? .lightGray : .black
     }
     
-    public func startAnimating() {
+    public func activateIndicator() {
         button.isUserInteractionEnabled = false
         
         activityIndicator.isHidden = false
         activityIndicator.startAnimating()
     }
     
-    public func stopAnimating() {
+    public func stopIndicator() {
         button.isUserInteractionEnabled = true
         
         activityIndicator.isHidden = true


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 닉네임 검증 시 사용되는 activityIndicator UI 구현 

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|중복 닉네임 일떄|중복 닉네임 아닐때|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/56781342/196165267-b05832b0-654b-44bb-aefa-925ccc342e74.gif">|<img width="250" src="https://user-images.githubusercontent.com/56781342/196165342-2694ae5f-d573-4154-a54a-656b9d609431.gif">|

### NickNameInputViewController
- 현재 50프로의 확률로 닉네임 중복 or 통과가 결정됩니다. 여러번 다음 버튼을 누르시면 spinner or 다음 뷰 이동을 볼 수 있어요.

### ShadowButton
- UIActivityIndicatorView 를 추가하여 스피너 동작을 구현하였습니다.
- activateIndicator, stopIndicator 메소드로 스피너 동작을 제어할 수 있습니다. 
- **사용시 주의사항:** button의 크기를 잡아주는 title 이나 imageView 혹은 constraint 가 필요합니다. (저는 title과 imageView를 hidden해서 사용했어요)

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- @YebinKim  리뷰 부탁드립니다~!!
- combine 사용이 자연스러운지, 어색한점 or 개선점이 있다면 말씀해주시면 감사하겠습니다!

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
