### PR TITLE
[Design] FullWidthBlackButton  컴포넌트 생성

### DIFF
--- a/Projects/DesignSystem/Sources/Component/FullWidthBlackButton.swift
+++ b/Projects/DesignSystem/Sources/Component/FullWidthBlackButton.swift
@@ -1,0 +1,42 @@
+//
+//  WideBlackButton.swift
+//  DesignSystem
+//
+//  Created by Lee Myeonghwan on 2022/10/20.
+//  Copyright © 2022 zesty. All rights reserved.
+//
+
+import UIKit
+
+public final class FullWidthBlackButton: UIButton {
+    
+    public init() {
+        super.init(frame: .zero)
+        configureUI()
+        createLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension FullWidthBlackButton {
+    
+    private func configureUI() {
+        configuration = .plain()
+        configuration?.contentInsets = .init(top: 17, leading: 0, bottom: 17, trailing: 0)
+        tintColor = .white
+        backgroundColor = .black
+        clipsToBounds = true
+        layer.cornerRadius = 27
+    }
+    
+    private func createLayout() {
+        snp.makeConstraints { make in
+            make.height.equalTo(55)
+        }
+    }
+    
+}


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] FullWidthBlackButton 생성

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

<img width="250" src="https://user-images.githubusercontent.com/56781342/196946196-875dc615-1a53-4e00-b7e8-cdd1a4226080.png">

### FullWidthBlackButton
<img width="543" alt="image" src="https://user-images.githubusercontent.com/56781342/196946631-d17289c5-9fb3-4cbd-8d77-5e76b9d54118.png">

- 높이 55 고정했어요
- center, y축, 좌우 constraints 잡아주고 사용할 수 있어요
- 왜인지 모르게 setAttributeTitle을 써야 글씨체와 크기가 먹어요.. (configuration 때문인가...🥲)

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 왜 그냥 setTitle해서 titleLabel font 하면 적용이 안되는지 아시는분..?

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

