### PR TITLE
[WIP][Design] 대학교 이메일 입력 뷰 UI

### DIFF
--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -1,0 +1,102 @@
+//
+//  DomainSettingViewController.swift
+//  App
+//
+//  Created by 김태호 on 2022/10/22.
+//  Copyright © 2022 zesty. All rights reserved.
+//
+
+import Combine
+import UIKit
+import DesignSystem
+import SnapKit
+
+final class DomainSettingViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    private let cancelBag = Set<AnyCancellable>()
+    
+    private let mainTitleView = MainTitleView(title: "학교 이메일을 알려주세요",
+                                              subtitle: "학교 인증에 사용돼요.")
+    private let domainInputBox = UIView()
+    private let domainStackView = UIStackView()
+    private let domainTextField = UITextField()
+    private let domainPlaceholder = UILabel()
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        createLayout()
+    }
+    
+    // MARK: - Function
+    
+}
+
+// MARK: - UI Function
+
+extension DomainSettingViewController {
+    
+    private func configureUI() {
+        domainInputBox.backgroundColor = .black
+        domainInputBox.layer.cornerRadius = 25
+        domainInputBox.layer.masksToBounds = true
+        
+        domainStackView.spacing = 10
+        domainStackView.axis = .horizontal
+        domainStackView.distribution = .fill
+        domainStackView.alignment = .fill
+        
+        domainTextField.attributedPlaceholder = .init(attributedString: NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray]))
+        domainTextField.textColor = .white
+        domainTextField.font = .systemFont(ofSize: 17, weight: .medium)
+        
+        domainPlaceholder.textColor = .white
+        domainPlaceholder.text = "@pos.idserve.net"
+        domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
+        domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
+    }
+    
+    private func createLayout() {
+        view.addSubviews([mainTitleView, domainInputBox])
+        
+        domainInputBox.addSubview(domainStackView)
+        domainStackView.addArrangedSubviews([domainTextField, domainPlaceholder])
+        
+        mainTitleView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.horizontalEdges.equalToSuperview()
+        }
+        
+        domainInputBox.snp.makeConstraints { make in
+            make.height.equalTo(50)
+            make.width.lessThanOrEqualTo(310)
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview()
+        }
+        
+        domainStackView.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview().inset(14)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.width.lessThanOrEqualTo(270)
+        }
+    }
+    
+}
+
+// MARK: - Previews
+
+#if DEBUG
+import SwiftUI
+
+struct DomainSettingViewControllerPreview: PreviewProvider {
+    
+    static var previews: some View {
+        DomainSettingViewController().toPreview()
+    }
+    
+}
+#endif

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -12,7 +12,7 @@ import DesignSystem
 import SnapKit
 
 final class DomainSettingViewController: UIViewController {
-    
+
     // MARK: - Properties
     
     private let viewModel = DomainSettingViewModel()
@@ -30,7 +30,7 @@ final class DomainSettingViewController: UIViewController {
     private let arrowButton = UIButton()
     
     private var keyboardUpConstraints: NSLayoutConstraint?
-    
+
     private var cancelBag = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
@@ -103,7 +103,7 @@ extension DomainSettingViewController {
         emailStackView.axis = .horizontal
         emailStackView.distribution = .fill
         emailStackView.alignment = .fill
-        
+
         emailTextField.becomeFirstResponder()
         emailTextField.attributedPlaceholder = .init(attributedString: NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray]))
         emailTextField.textColor = .white
@@ -154,7 +154,7 @@ extension DomainSettingViewController {
         keyboardSafeArea.snp.makeConstraints { make in
             make.top.equalTo(mainTitleView.snp.bottom)
             make.horizontalEdges.equalToSuperview()
-            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(keyboardHeight)
+            make.bottom.equalToSuperview().inset(keyboardHeight)
         }
         
         emailInputView.snp.makeConstraints { make in

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -57,19 +57,11 @@ extension DomainSettingViewController {
         viewModel.$isEmailValid
             .sink {[weak self] isValid in
                 // TODO: button disalbed로 변경하기
-                self?.arrowButton.layer.borderColor = isValid ? UIColor.black.cgColor : UIColor.lightGray.cgColor
-                self?.arrowButton.tintColor = isValid ? .black : .lightGray
-            }
-            .store(in: &cancelBag)
-        
-        viewModel.$isDuplicateEamil
-            .sink {[weak self] isDuplicateEmail  in
                 guard let self = self else { return }
-                self.domainDuplicatedLabel.isHidden = !isDuplicateEmail
-            
+                self.arrowButton.layer.borderColor = isValid ? UIColor.black.cgColor : UIColor.lightGray.cgColor
+                self.arrowButton.tintColor = isValid ? .black : .lightGray
             }
             .store(in: &cancelBag)
-        
         NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
             .sink { [weak self] notification in
                 guard let self = self else { return }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -69,6 +69,7 @@ extension DomainSettingViewController {
                 guard let self = self else { return }
                 self.emailDuplicatedLabel.isHidden = !isDuplicateEmail
             }
+            .store(in: &cancelBag)
         
         NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
             .sink { [weak self] notification in

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -21,15 +21,14 @@ final class DomainSettingViewController: UIViewController {
     private let domainInputBox = UIView()
     private let domainStackView = UIStackView()
     private let domainTextField = UITextField()
+    private let domainDuplicatedLabel = UILabel()
     private let domainPlaceholder = UILabel()
     
     // TODO: component로 변경하기
     private let arrowButton = UIButton()
     
     private var keyboardUpConstraints: NSLayoutConstraint?
-    
-    private var isButtonValid: Bool = false
-    
+
     private var cancelBag = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
@@ -58,9 +57,16 @@ extension DomainSettingViewController {
         viewModel.$isEmailValid
             .sink {[weak self] isValid in
                 // TODO: button disalbed로 변경하기
-                print(isValid)
                 self?.arrowButton.layer.borderColor = isValid ? UIColor.black.cgColor : UIColor.lightGray.cgColor
                 self?.arrowButton.tintColor = isValid ? .black : .lightGray
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.$isDuplicateEamil
+            .sink {[weak self] isDuplicateEmail  in
+                guard let self = self else { return }
+                self.domainDuplicatedLabel.isHidden = !isDuplicateEmail
+            
             }
             .store(in: &cancelBag)
         
@@ -107,6 +113,10 @@ extension DomainSettingViewController {
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
         
+        domainDuplicatedLabel.textColor = .red
+        domainDuplicatedLabel.text = "이미 사용된 이메일이에요."
+        domainDuplicatedLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        
         // TODO: Component로 변경
         arrowButton.tintColor = .lightGray
         arrowButton.backgroundColor = .white
@@ -115,7 +125,7 @@ extension DomainSettingViewController {
         arrowButton.clipsToBounds = true
         arrowButton.layer.borderWidth = 2
         arrowButton.layer.cornerRadius = 25
-        arrowButton.layer.borderColor = UIColor.black.cgColor
+        arrowButton.layer.borderColor = UIColor.lightGray.cgColor
 
         let arrowImageConfiguration = UIImage.SymbolConfiguration(pointSize: 16, weight: .bold, scale: .default)
         let arrowImage = UIImage(systemName: "arrow.forward", withConfiguration: arrowImageConfiguration)
@@ -123,7 +133,7 @@ extension DomainSettingViewController {
     }
     
     private func createLayout() {
-        view.addSubviews([mainTitleView, domainInputBox, arrowButton])
+        view.addSubviews([mainTitleView, domainInputBox, domainDuplicatedLabel, arrowButton])
         
         domainInputBox.addSubview(domainStackView)
         domainStackView.addArrangedSubviews([domainTextField, domainPlaceholder])
@@ -144,6 +154,11 @@ extension DomainSettingViewController {
             make.verticalEdges.equalToSuperview().inset(14)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.width.lessThanOrEqualTo(270)
+        }
+        
+        domainDuplicatedLabel.snp.makeConstraints { make in
+            make.top.equalTo(domainInputBox.snp.bottom).offset(15)
+            make.centerX.equalToSuperview()
         }
         
         arrowButton.snp.makeConstraints { make in

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -17,11 +17,12 @@ final class DomainSettingViewController: UIViewController {
     
     private let viewModel = DomainSettingViewModel()
     
-    private let mainTitleView = MainTitleView(title: "학교 이메일을 알려주세요", subtitle: "학교 인증에 사용돼요.")
-    private let domainInputBox = UIView()
-    private let domainStackView = UIStackView()
-    private let domainTextField = UITextField()
-    private let domainDuplicatedLabel = UILabel()
+    private let mainTitleView = MainTitleView(title: "학교 이메일을 알려주세요",
+                                              subtitle: "학교 인증에 사용돼요.")
+    private let emailInputView = UIView()
+    private let emailStackView = UIStackView()
+    private let emailTextField = UITextField()
+    private let emailDuplicatedLabel = UILabel()
     private let domainPlaceholder = UILabel()
     
     // TODO: component로 변경하기
@@ -49,7 +50,7 @@ final class DomainSettingViewController: UIViewController {
 extension DomainSettingViewController {
     
     private func bindUI() {
-        domainTextField.textDidChangePublisher
+        emailTextField.textDidChangePublisher
                         .compactMap { $0.text }
                         .assign(to: \.userEmail, on: viewModel)
                         .store(in: &cancelBag)
@@ -62,6 +63,13 @@ extension DomainSettingViewController {
                 self.arrowButton.tintColor = isValid ? .black : .lightGray
             }
             .store(in: &cancelBag)
+        
+        viewModel.$isDuplicateEmail
+            .sink { [weak self] isDuplicateEmail in
+                guard let self = self else { return }
+                self.emailDuplicatedLabel.isHidden = !isDuplicateEmail
+            }
+        
         NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
             .sink { [weak self] notification in
                 guard let self = self else { return }
@@ -85,29 +93,29 @@ extension DomainSettingViewController {
     private func configureUI() {
         view.backgroundColor = .white
         
-        domainInputBox.backgroundColor = .black
-        domainInputBox.layer.cornerRadius = 25
-        domainInputBox.layer.masksToBounds = true
+        emailInputView.backgroundColor = .black
+        emailInputView.layer.cornerRadius = 25
+        emailInputView.layer.masksToBounds = true
         
-        domainStackView.spacing = 10
-        domainStackView.axis = .horizontal
-        domainStackView.distribution = .fill
-        domainStackView.alignment = .fill
+        emailStackView.spacing = 10
+        emailStackView.axis = .horizontal
+        emailStackView.distribution = .fill
+        emailStackView.alignment = .fill
        
-        domainTextField.becomeFirstResponder()
-        domainTextField.attributedPlaceholder = .init(attributedString: NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray]))
-        domainTextField.textColor = .white
-        domainTextField.font = .systemFont(ofSize: 17, weight: .medium)
-        domainTextField.keyboardType = .asciiCapable
+        emailTextField.becomeFirstResponder()
+        emailTextField.attributedPlaceholder = .init(attributedString: NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray]))
+        emailTextField.textColor = .white
+        emailTextField.font = .systemFont(ofSize: 17, weight: .medium)
+        emailTextField.keyboardType = .asciiCapable
         
         domainPlaceholder.textColor = .white
         domainPlaceholder.text = "@pos.idserve.net"
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
         
-        domainDuplicatedLabel.textColor = .red
-        domainDuplicatedLabel.text = "이미 사용된 이메일이에요."
-        domainDuplicatedLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        emailDuplicatedLabel.textColor = .red
+        emailDuplicatedLabel.text = "이미 사용된 이메일이에요."
+        emailDuplicatedLabel.font = .systemFont(ofSize: 13, weight: .regular)
         
         // TODO: Component로 변경
         arrowButton.tintColor = .lightGray
@@ -125,31 +133,31 @@ extension DomainSettingViewController {
     }
     
     private func createLayout() {
-        view.addSubviews([mainTitleView, domainInputBox, domainDuplicatedLabel, arrowButton])
+        view.addSubviews([mainTitleView, emailInputView, emailDuplicatedLabel, arrowButton])
         
-        domainInputBox.addSubview(domainStackView)
-        domainStackView.addArrangedSubviews([domainTextField, domainPlaceholder])
+        emailInputView.addSubview(emailStackView)
+        emailStackView.addArrangedSubviews([emailTextField, domainPlaceholder])
         
         mainTitleView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
             make.horizontalEdges.equalToSuperview()
         }
         
-        domainInputBox.snp.makeConstraints { make in
+        emailInputView.snp.makeConstraints { make in
             make.top.equalTo(mainTitleView.snp.bottom).offset(160)
             make.centerX.equalToSuperview()
             make.height.equalTo(50)
             make.width.lessThanOrEqualTo(310)
         }
         
-        domainStackView.snp.makeConstraints { make in
+        emailStackView.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview().inset(14)
             make.horizontalEdges.equalToSuperview().inset(20)
             make.width.lessThanOrEqualTo(270)
         }
         
-        domainDuplicatedLabel.snp.makeConstraints { make in
-            make.top.equalTo(domainInputBox.snp.bottom).offset(15)
+        emailDuplicatedLabel.snp.makeConstraints { make in
+            make.top.equalTo(emailInputView.snp.bottom).offset(15)
             make.centerX.equalToSuperview()
         }
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -25,9 +25,15 @@ final class DomainSettingViewController: UIViewController {
     private let domainTextField = UITextField()
     private let domainPlaceholder = UILabel()
     
+    // TODO: component로 변경하기
     private let arrowButton = UIButton()
     
+    private var keyboardUpConstraints: NSLayoutConstraint?
+    private var keyboardDownConstraints: NSLayoutConstraint?
+    
     private var isButtonValid: Bool = false
+    
+    private var cancelBag = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
     
@@ -42,20 +48,21 @@ final class DomainSettingViewController: UIViewController {
     
 }
 
-// MARK: - Bind UI
+// MARK: - Bind Function
+
 extension DomainSettingViewController {
     private func bindUI() {
         domainTextField.textDidChangePublisher
                         .compactMap { $0.text }
-                        .receive(on: DispatchQueue.main)
                         .assign(to: \.userEmail, on: viewModel)
                         .store(in: &cancelBag)
         
         viewModel.$isEmailValid
             .sink {[weak self] isValid in
+                // TODO: button disalbed로 변경하기
                 print(isValid)
-                self?.arrowButton.backgroundColor = isValid ? .white : .gray
-                self?.arrowButton.tintColor = isValid ? .black : .darkGray
+                self?.arrowButton.layer.borderColor = isValid ? UIColor.black.cgColor : UIColor.lightGray.cgColor
+                self?.arrowButton.tintColor = isValid ? .black : .lightGray
             }
             .store(in: &cancelBag)
     }
@@ -76,7 +83,8 @@ extension DomainSettingViewController {
         domainStackView.axis = .horizontal
         domainStackView.distribution = .fill
         domainStackView.alignment = .fill
-        
+       
+        domainTextField.becomeFirstResponder()
         domainTextField.attributedPlaceholder = .init(attributedString: NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray]))
         domainTextField.textColor = .white
         domainTextField.font = .systemFont(ofSize: 17, weight: .medium)
@@ -88,12 +96,13 @@ extension DomainSettingViewController {
         
         // TODO: Component로 변경
         arrowButton.tintColor = .darkGray
-        arrowButton.backgroundColor = .gray
+        arrowButton.backgroundColor = .white
         arrowButton.configuration = .plain()
         arrowButton.configuration?.contentInsets = .init(top: 14.5, leading: 15, bottom: 14.5, trailing: 15)
         arrowButton.clipsToBounds = true
         arrowButton.layer.borderWidth = 2
         arrowButton.layer.cornerRadius = 25
+        arrowButton.layer.borderColor = UIColor.black.cgColor
 
         let arrowImageConfiguration = UIImage.SymbolConfiguration(pointSize: 16, weight: .bold, scale: .default)
         let arrowImage = UIImage(systemName: "arrow.forward", withConfiguration: arrowImageConfiguration)
@@ -112,10 +121,10 @@ extension DomainSettingViewController {
         }
         
         domainInputBox.snp.makeConstraints { make in
+            make.top.equalTo(mainTitleView.snp.bottom).offset(160)
+            make.centerX.equalToSuperview()
             make.height.equalTo(50)
             make.width.lessThanOrEqualTo(310)
-            make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview()
         }
         
         domainStackView.snp.makeConstraints { make in
@@ -125,7 +134,7 @@ extension DomainSettingViewController {
         }
         
         arrowButton.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(20)
+            make.top.equalTo(domainInputBox.snp.bottom).offset(89)
             make.right.equalToSuperview().inset(20)
         }
     }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -93,6 +93,9 @@ extension DomainSettingViewController {
     private func configureUI() {
         view.backgroundColor = .white
         
+        self.navigationController?.navigationBar.tintColor = .black
+        self.navigationController?.navigationBar.topItem?.title = ""
+        
         emailInputView.backgroundColor = .black
         emailInputView.layer.cornerRadius = 25
         emailInputView.layer.masksToBounds = true

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -17,8 +17,7 @@ final class DomainSettingViewModel {
     @Published var isEmailValid = false
     @Published var isDuplicateEamil = false
     
-    private var orgArray: [Organization] = []
-    private var orgDomain: String = ""
+    var orgDomain: String = ""
     
     private var cancelBag = Set<AnyCancellable>()
     
@@ -33,7 +32,9 @@ final class DomainSettingViewModel {
 // MARK: - Logic
 
 extension DomainSettingViewModel {
+    
     private func checkEmailValid(email: String) -> Bool {
         return !email.isEmpty
     }
+    
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -15,6 +15,7 @@ final class DomainSettingViewModel {
     
     // output
     @Published var isEmailValid = false
+    @Published var isDuplicateEamil = false
     
     private var orgArray: [Organization] = []
     private var orgDomain: String = ""
@@ -33,7 +34,6 @@ final class DomainSettingViewModel {
 
 extension DomainSettingViewModel {
     private func checkEmailValid(email: String) -> Bool {
-        print("변경이 일어났습니다 : \(email)")
         return !email.isEmpty
     }
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -16,6 +16,7 @@ final class DomainSettingViewModel {
     // output
     @Published var isEmailValid = false
     @Published var isDuplicateEmail = false
+    @Published var isButtonValid = false
     
     var orgDomain: String = ""
     

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -15,7 +15,7 @@ final class DomainSettingViewModel {
     
     // output
     @Published var isEmailValid = false
-    @Published var isDuplicateEamil = false
+    @Published var isDuplicateEmail = false
     
     var orgDomain: String = ""
     

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  DomainSettingViewModel.swift
+//  App
+//
+//  Created by 김태호 on 2022/10/22.
+//  Copyright © 2022 zesty. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+final class DomainSettingViewModel {
+    // input
+    @Published var userEmail: String = ""
+    
+    // output
+    @Published var isEmailValid = false
+    
+    private var orgArray: [Organization] = []
+    private var orgDomain: String = ""
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    init() {
+        $userEmail
+            .map(checkEmailValid)
+            .assign(to: \.isEmailValid, on: self)
+            .store(in: &cancelBag)
+    }
+}
+
+// MARK: - Logic
+
+extension DomainSettingViewModel {
+    private func checkEmailValid(email: String) -> Bool {
+        print("변경이 일어났습니다 : \(email)")
+        return !email.isEmpty
+    }
+}

--- a/Projects/App/Sources/UI/Organization/OrganizationList/ViewModel/OrganizatinoListViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/OrganizationList/ViewModel/OrganizatinoListViewModel.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 zesty. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 final class OrganizationListViewModel {
     


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 대학교 이메일 입력 뷰 추가
- [x] 고반의 arrowButton을 추가

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|이메일 입력 전|이메일 입력 후|이메일 중복 시|
|:---:|:---:|:---:|
|<img width="250" src="">|<img width="250" src="">

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
### 키보드 높이에 따라 이메일 입력 박스와 화살표 버튼의 이동
 - 현재 뷰에서는 키보드가 올라온 상태에서 내려가는 일이 없기 때문에 키보드 높이에 따라 컴포넌트들이 올라오는 기능만 구현했습니다
### 이메일 중복 검사 
 - 현재는 UI(라벨)만 추가했습니다. 이 부분은 로직을 구현할 때 빠르게 작업하도록 하겠습니다
 
## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max
