### PR TITLE
[Setting] AWSS3 package 추가

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -10,6 +10,24 @@
       }
     },
     {
+      "identity" : "aws-crt-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-crt-swift.git",
+      "state" : {
+        "revision" : "d654b82a55aec736ad8b4354027acab17394a060",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "aws-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-sdk-swift",
+      "state" : {
+        "revision" : "f412e57672dddce5424dde18e18673abb885e5a9",
+        "version" : "0.3.1"
+      }
+    },
+    {
       "identity" : "kakao-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
@@ -28,12 +46,48 @@
       }
     },
     {
+      "identity" : "smithy-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/smithy-swift.git",
+      "state" : {
+        "revision" : "5b7b9bdc459b599d394d6f38ef6c61d6f0ed2090",
+        "version" : "0.3.0"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
+      "state" : {
+        "revision" : "ca932442d7481700f5434a7b138c47dd42d9902b",
+        "version" : "0.14.0"
       }
     }
   ],

--- a/.package.resolved
+++ b/.package.resolved
@@ -19,6 +19,24 @@
       }
     },
     {
+      "identity" : "aws-crt-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-crt-swift.git",
+      "state" : {
+        "revision" : "d654b82a55aec736ad8b4354027acab17394a060",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "aws-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-sdk-swift",
+      "state" : {
+        "revision" : "f412e57672dddce5424dde18e18673abb885e5a9",
+        "version" : "0.3.1"
+      }
+    },
+    {
       "identity" : "boringssl-swiftpm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
@@ -79,24 +97,6 @@
       "state" : {
         "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
         "version" : "2.1.0"
-      }
-    },
-    {
-      "identity" : "aws-crt-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-crt-swift.git",
-      "state" : {
-        "revision" : "d654b82a55aec736ad8b4354027acab17394a060",
-        "version" : "0.2.2"
-      }
-    },
-    {
-      "identity" : "aws-sdk-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-sdk-swift",
-      "state" : {
-        "revision" : "f412e57672dddce5424dde18e18673abb885e5a9",
-        "version" : "0.3.1"
       }
     },
     {
@@ -163,15 +163,6 @@
       }
     },
     {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
-        "version" : "1.20.2"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
@@ -187,6 +178,15 @@
       "state" : {
         "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
         "version" : "1.4.4"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
       }
     },
     {

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -15,14 +15,16 @@ let project = Project.makeAppModule(
     packages: [
         .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.0.1")),
         .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
-        .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.11.3"))
+        .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.11.3")),
+        .remote(url: "https://github.com/awslabs/aws-sdk-swift", requirement: .upToNextMajor(from: "0.3.1"))
     ],
     dependencies: [
         .Projcet.Network,
         .Projcet.DesignSystem,
         .package(product: "KakaoSDK"),
         .package(product: "SnapKit"),
-        .package(product: "Kingfisher")
+        .package(product: "Kingfisher"),
+        .package(product: "AWSS3")
     ],
     resources: ["Resources/**"],
     infoPlist: .file(path: "Sources/Application/Info.plist")

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -23,8 +23,7 @@ let project = Project.makeAppModule(
         .Projcet.DesignSystem,
         .package(product: "KakaoSDK"),
         .package(product: "SnapKit"),
-        .package(product: "Kingfisher"),
-        .package(product: "AWSS3")
+        .package(product: "Kingfisher")
     ],
     resources: ["Resources/**"],
     infoPlist: .file(path: "Sources/Application/Info.plist")

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -16,7 +16,7 @@ let project = Project.makeAppModule(
         .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.0.1")),
         .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
         .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.11.3")),
-        .remote(url: "https://github.com/awslabs/aws-sdk-swift", requirement: .upToNextMajor(from: "0.3.1"))
+        .remote(url: "https://github.com/awslabs/aws-sdk-swift", requirement: .upToNextMajor(from: "0.3.1")),
         .remote(url: "https://github.com/firebase/firebase-ios-sdk", requirement: .upToNextMajor(from: "9.0.0"))
     ],
     dependencies: [

--- a/Projects/Network/Project.swift
+++ b/Projects/Network/Project.swift
@@ -11,6 +11,10 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: "Network",
     product: .staticFramework,
+    packages: [
+        .remote(url: "https://github.com/awslabs/aws-sdk-swift", requirement: .upToNextMajor(from: "0.3.1"))
+    ],
     dependencies: [
+        .package(product: "AWSS3")
     ]
 )


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 이미지를 AWS S3 에 업로드하기 위한 package를 network 모듈 dependecy에 추가했습니다.

<img width="305" alt="image" src="https://user-images.githubusercontent.com/56781342/197921277-f91aabf3-2f52-4c9d-a4f0-5bde58d333a2.png">

### AWS S3 (aws-sdk-swift)의 dependency
- aws-crt-swift
- smithy-swift
- swift-collections
- swift-log
- xmlcoder

많네요

<img width="532" alt="image" src="https://user-images.githubusercontent.com/56781342/197923003-4998607b-ee58-4e98-89a6-01aef1986981.png">

그런데 지금 방식으로는 설정해놓은 dependency가 아니더라도 모든 모듈이 사용할 수 있네요?

이부분이 조금 이상하고 모듈로 나눠놓은 의미가 조금 퇴색되는 느낌이 있네요

조만간 조금 더 공부해서 tuist의 dependency.swift 로 관리하는 것을 고려해보겠습니다.


## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

