### PR TITLE
[Setting] dependency들을 tuist dependencies.swift 에서 관리

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -12,19 +12,13 @@ let project = Project.makeAppModule(
     name: "App",
     platform: .iOS,
     product: .app,
-    packages: [
-        .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.0.1")),
-        .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
-        .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.11.3")),
-        .remote(url: "https://github.com/firebase/firebase-ios-sdk", requirement: .upToNextMajor(from: "9.0.0"))
-    ],
     dependencies: [
         .Projcet.Network,
         .Projcet.DesignSystem,
-        .package(product: "KakaoSDK"),
-        .package(product: "SnapKit"),
-        .package(product: "Kingfisher"),
-        .package(product: "FirebaseAnalytics")
+        .external(name: "KakaoSDK"),
+        .external(name: "SnapKit"),
+        .external(name: "Kingfisher"),
+        .external(name: "FirebaseAnalytics")
     ],
     resources: ["Resources/**"],
     infoPlist: .file(path: "Sources/Application/Info.plist")

--- a/Projects/Network/Project.swift
+++ b/Projects/Network/Project.swift
@@ -11,10 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.makeModule(
     name: "Network",
     product: .staticFramework,
-    packages: [
-        .remote(url: "https://github.com/aws-amplify/aws-sdk-ios-spm", requirement: .upToNextMajor(from: "2.28.0"))
-    ],
     dependencies: [
-        .package(product: "AWSS3")
+        .external(name: "AWSS3")
     ]
 )

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,0 +1,19 @@
+//
+//  Dependencies.swift
+//  Config
+//
+//  Created by Lee Myeonghwan on 2022/10/27.
+//
+
+import ProjectDescription
+
+let dependencies = Dependencies(
+    swiftPackageManager: [
+        .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.0.1")),
+        .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
+        .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.11.3")),
+        .remote(url: "https://github.com/firebase/firebase-ios-sdk", requirement: .upToNextMajor(from: "9.0.0")),
+        .remote(url: "https://github.com/aws-amplify/aws-sdk-ios-spm", requirement: .upToNextMajor(from: "2.28.0"))
+    ],
+    platforms: [.iOS]
+)


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] xcode 상에서 dependecy 를 추가하는 방식에서 tuist dependencies.swift를 이용하여 관리하는 방식으로 변경

dependency가 늘어나고 커져서 잦은 오류, 오랜 빌드시간 때문에 tuist dependencies.swift를 사용하는 방식으로 변경하였습니다.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/56781342/198093760-527312e8-317b-4f99-a43a-8a81a739314f.png">

이제는 로컬에 저장된 공유 package를 불러와서 사용해요. 

# 필독 
**그래서 tuist fetch로 package를 로컬에 저장하는 동작이 필요합니다.**

바꾸고 나서야 이게 진정한 tuist가 아닌가 생각이 드네요


### Tip
<img width="385" alt="image" src="https://user-images.githubusercontent.com/56781342/198093135-ce3e54e1-3b7d-4b7f-b2de-9f1673f32851.png">

이렇게 alias 설정해두면 새로운 패키지 추가가 있을때 tb 로 프로젝트 바로 열 수 있어요
(새로운 패키지 추가되면 그떄만 tuist fetch 하면 돼요)

