### PR TITLE
[Fix] 맛집 리스트 crash 현상 및 레이아웃 깨짐 이슈 해결

### DIFF
--- a/Projects/App/Sources/Application/AppDelegate.swift
+++ b/Projects/App/Sources/Application/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        UINavigationBar.setOpacityAppearance()
+        
         FirebaseApp.configure()
         if let kakaoNativeAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String {
             KakaoSDK.initSDK(appKey: kakaoNativeAppKey)

--- a/Projects/App/Sources/Domain/Category/Category.swift
+++ b/Projects/App/Sources/Domain/Category/Category.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Category {
+struct Category: Hashable {
     let id: Int
     let name: String
     let imageURL: String?

--- a/Projects/App/Sources/Domain/Place/Place.swift
+++ b/Projects/App/Sources/Domain/Place/Place.swift
@@ -9,7 +9,8 @@
 import Foundation
 import Network
 
-struct Place {
+struct Place: Hashable {
+    let uuid = UUID()
     let id: Int
     let kakaoPlaceId: Int
     let creator: User?
@@ -23,7 +24,7 @@ struct Place {
     let reviews: [Review] // Preview Image
 }
 
-struct EvaluationSum {
+struct EvaluationSum: Hashable {
     let good: Int
     let soso: Int
     let bad: Int

--- a/Projects/App/Sources/Domain/Place/PlaceUseCase.swift
+++ b/Projects/App/Sources/Domain/Place/PlaceUseCase.swift
@@ -12,22 +12,26 @@ import Network
 
 final class PlaceListUseCase {
     
-    private var cancelBag = Set<AnyCancellable>()
-    
-    func fetchPlaceList(with page: Int) -> AnyPublisher<[Place], NetworkError> {
-        return PlaceAPI.fetchPlaceList(with: page)
+    func fetchPlaceList(with page: Int, type: PlaceType) -> AnyPublisher<[Place], NetworkError> {
+        let api: AnyPublisher<PlaceListDTO, NetworkError>
+        
+        switch type {
+        case .whole:
+            api = PlaceAPI.fetchPlaceList(with: page)
+        case .hot:
+            api = PlaceAPI.fetchHotPlaceList(with: page)
+        }
+        
+        return api
             .map { placeList in
                 placeList.map { Place(dto: $0) }
             }
             .eraseToAnyPublisher()
     }
     
-    func fetchHotPlaceList(with page: Int) -> AnyPublisher<[Place], NetworkError> {
-        return PlaceAPI.fetchHotPlaceList(with: page)
-            .map { placeList in
-                placeList.map { Place(dto: $0) }
-            }
-            .eraseToAnyPublisher()
-    }
-    
+}
+
+enum PlaceType {
+    case whole
+    case hot
 }

--- a/Projects/App/Sources/Domain/Review/Review.swift
+++ b/Projects/App/Sources/Domain/Review/Review.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Network
 
-struct Review {
+struct Review: Hashable {
     let id: Int
     let placeId: Int
     let reviewer: User?
@@ -20,7 +20,7 @@ struct Review {
 //    let updatedAt: Date
 }
 
-enum Evaluation: Int {
+enum Evaluation: Int, Hashable {
     case good = 3
     case soso = 2
     case bad = 1

--- a/Projects/App/Sources/Domain/User/User.swift
+++ b/Projects/App/Sources/Domain/User/User.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Network
 
-struct User {
+struct User: Hashable {
     let id: Int
     let email: String
     let social: SocialProvider

--- a/Projects/App/Sources/Global/Extension/NavigationBar+.swift
+++ b/Projects/App/Sources/Global/Extension/NavigationBar+.swift
@@ -15,7 +15,6 @@ extension UINavigationBar {
             // 네비게이션바 설정
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()
-            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
             
             // 네비게이션바 배경색
             appearance.backgroundColor = .white

--- a/Projects/App/Sources/Global/Extension/NavigationBar+.swift
+++ b/Projects/App/Sources/Global/Extension/NavigationBar+.swift
@@ -1,0 +1,31 @@
+//
+//  NavigationBar+.swift
+//  App
+//
+//  Created by 리아 on 2022/11/04.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationBar {
+    
+    static func setOpacityAppearance() {
+        if #available(iOS 15, *) {
+            // 네비게이션바 설정
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+            
+            // 네비게이션바 배경색
+            appearance.backgroundColor = .white
+            
+            // 아래 회색 라인 없애기
+            appearance.shadowColor = .clear
+            
+            Self.appearance().standardAppearance = appearance
+            Self.appearance().scrollEdgeAppearance = appearance
+        }
+    }
+    
+}

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import DesignSystem
 
-final class PlaceCell: UITableViewCell {
+final class PlaceCell: UICollectionViewCell {
     // TODO: 리뷰가 없는 상황을 가정한 cell입니다. 변경 예정
     
     // MARK: - Properties
@@ -37,8 +37,8 @@ final class PlaceCell: UITableViewCell {
     
     // MARK: - LifeCycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         createLayout()
         configureUI()
     }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
@@ -11,7 +11,6 @@ import SnapKit
 import DesignSystem
 
 final class PlaceCell: UICollectionViewCell {
-    // TODO: 리뷰가 없는 상황을 가정한 cell입니다. 변경 예정
     
     // MARK: - Properties
     

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
@@ -132,15 +132,15 @@ extension PlaceCell {
 
         containerView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(45)
-            $0.top.height.equalToSuperview().inset(15)
+            $0.verticalEdges.equalToSuperview().inset(15)
         }
         
         scrollView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(scrollView.snp.width)
+            $0.height.equalTo(containerView.snp.width)
         }
         pageStackView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
             $0.height.equalTo(containerView.snp.width)
         }
         pageControl.snp.makeConstraints {
@@ -149,7 +149,7 @@ extension PlaceCell {
         }
         
         bottomView.snp.makeConstraints { make in
-            make.top.equalTo(scrollView.snp.bottom)
+            make.top.equalTo(scrollView.snp.bottom).priority(.medium)
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }
@@ -160,7 +160,6 @@ extension PlaceCell {
         emojiStackView.snp.makeConstraints { make in
             make.top.equalTo(placeNameLabel.snp.bottom).offset(10)
             make.leading.bottom.equalToSuperview().inset(20)
-            make.height.equalTo(30)
         }
     }
     

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
@@ -101,8 +101,11 @@ extension PlaceCell {
     }
 
     private func configureUI() {
+        contentView.addGestureRecognizer(scrollView.panGestureRecognizer)
+        
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.isPagingEnabled = true
+        scrollView.isUserInteractionEnabled = false
         scrollView.delegate = self
         
         pageStackView.axis = .horizontal

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -1,8 +1,9 @@
 //
-//  SubPlaceListViewControllerViewController.swift
+//  PlaceListViewController.swift
 //  App
 //
 //  Created by 김태호 on 2022/10/25.
+//  Updated by 리아 on 2022/11/01.
 //  Copyright (c) 2022 zesty. All rights reserved.
 //
 
@@ -16,15 +17,14 @@ final class PlaceListViewController: UIViewController {
 
     private var cancelBag = Set<AnyCancellable>()
     private let viewModel: PlaceListViewModel
-
-    private let headerView = UIView()
-    private let segmentIndicator = UIView()
-    private let segmentedControl = UISegmentedControl(items: ["전체", "선정맛집"])
     
-    private let questionButton = UIButton()
-    private let addPlaceButton = UIButton()
+    typealias DataSource = UICollectionViewDiffableDataSource<Int, Place>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Int, Place>
     
-    private let tableView = UITableView()
+    private var collectionView: UICollectionView!
+    private var dataSource: DataSource!
+    private var snapshot = Snapshot()
+    private let headerType = "section-header-element-kind"
     
     // MARK: - LifeCycle
     
@@ -39,9 +39,11 @@ final class PlaceListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
-        createLayout()
-        bind()
+//        configureUI()
+//        configureHierarchy()
+//        configureDataSource()
+//        applyInitialSnapShot()
+//        bind()
     }
     
     // MARK: - Function
@@ -49,44 +51,24 @@ final class PlaceListViewController: UIViewController {
     private func bind() {
         viewModel.$result
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] places in
                 guard let self = self else { return }
-                self.tableView.reloadData()
+                self.snapshot.appendItems(places)
+                self.dataSource.apply(self.snapshot)
             }
             .store(in: &cancelBag)
     }
 
 }
 
-extension PlaceListViewController: UITableViewDataSource, UITableViewDataSourcePrefetching {
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.result.count
-    }
+extension PlaceListViewController: UICollectionViewDataSourcePrefetching, UICollectionViewDelegate {
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: PlaceCell.identifier, for: indexPath) as? PlaceCell
-        guard let cell = cell else { return UITableViewCell() }
-        let place = viewModel.result[indexPath.row]
-        cell.setUp(with: place)
-        cell.selectionStyle = .none
-        return cell
-    }
-    
-    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+    func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         let rows = indexPaths.map { $0.row }
         viewModel.prefetch(at: rows)
     }
     
-}
-
-extension PlaceListViewController: UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let placeId = viewModel.result[indexPath.row].id
         let placeDetailViewModel = PlaceDetailViewModel(placeId: placeId)
         show(PlaceDetailViewController(viewModel: placeDetailViewModel), sender: nil)
@@ -97,38 +79,6 @@ extension PlaceListViewController: UITableViewDelegate {
 // MARK: - UI function
 
 extension PlaceListViewController {
-    
-    @objc func indexChanged(_ sender: UISegmentedControl) {
-        let numberOfSegments = CGFloat(segmentedControl.numberOfSegments)
-        let selectedIndex = CGFloat(sender.selectedSegmentIndex)
-        let titlecount = CGFloat((segmentedControl.titleForSegment(at: sender.selectedSegmentIndex)!.count))
-        if selectedIndex == 1 {
-            viewModel.placeType = .hot
-            segmentIndicator.snp.remakeConstraints { (make) in
-                make.top.equalTo(segmentedControl.snp.bottom).offset(3)
-                make.height.equalTo(3)
-                make.width.equalTo(titlecount * 11)
-                make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(numberOfSegments / CGFloat(2.58 + CGFloat(selectedIndex-1.0)*2.0))
-            }
-        } else {
-            viewModel.placeType = .whole
-            segmentIndicator.snp.makeConstraints { make in
-                make.top.equalTo(segmentedControl.snp.bottom).offset(3)
-                make.height.equalTo(3)
-                make.width.equalTo(20)
-                make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(segmentedControl.numberOfSegments)
-            }
-        }
-        
-        UIView.animate(withDuration: 0.3, animations: {
-            self.view.layoutIfNeeded()
-            self.segmentIndicator.transform = CGAffineTransform(scaleX: 1.1, y: 1)
-        }) { _ in
-            UIView.animate(withDuration: 0.4, animations: {
-                self.segmentIndicator.transform = CGAffineTransform.identity
-            })
-        }
-    }
     
     @objc func searchButtonTapped() {
         // TODO: 검색뷰 완성 시 연결
@@ -141,9 +91,63 @@ extension PlaceListViewController {
         // TODO: 민이 만든 프로필 뷰로 이동
          navigationController?.pushViewController(ProfileViewController(), animated: true)
     }
+
+}
+
+// MARK: - Configure CollectionView
+
+extension PlaceListViewController {
+
+    private func configureHierarchy() {
+        collectionView = UICollectionView(frame: view.frame, collectionViewLayout: createLayout())
+        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        collectionView.backgroundColor = .clear
+        collectionView.delegate = self
+        view.addSubview(collectionView)
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        let section: NSCollectionLayoutSection
+        let margin: CGFloat = 10
+        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(90))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(90))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        section = NSCollectionLayoutSection(group: group)
+        
+        let sectionHeaderSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(85))
+        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: sectionHeaderSize,
+                                                                        elementKind: headerType,
+                                                                        alignment: .topLeading)
+        section.boundarySupplementaryItems = [sectionHeader]
+        section.contentInsets = NSDirectionalEdgeInsets(top: margin, leading: margin, bottom: margin, trailing: margin)
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
     
-    @objc func addPlaceButtonTapped() {
-        navigationController?.pushViewController(AddPlaceSearchViewController(viewModel: AddPlaceSearchViewModel()), animated: true)
+    private func configureDataSource() {
+        let cellRegisteration = UICollectionView.CellRegistration<PlaceCell, Place> { cell, _, item in
+            cell.setUp(with: item)
+        }
+        typealias SupplymentaryViewRegistration = UICollectionView.SupplementaryRegistration<SegmentHeaderView>
+        let headerRegisteration = SupplymentaryViewRegistration(elementKind: headerType) { [weak self] supplementaryView, _, _ in
+            guard let self = self else { return }
+            supplementaryView.viewModel = self.viewModel
+        }
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegisteration, for: indexPath, item: item)
+        })
+        dataSource.supplementaryViewProvider = { collectionView, _, index in
+            return self.collectionView.dequeueConfiguredReusableSupplementary(using: headerRegisteration, for: index)
+        }
+    }
+
+    private func applyInitialSnapShot() {
+        snapshot.appendSections([1])
+        snapshot.appendItems([], toSection: 1)
+        dataSource.apply(snapshot)
     }
 
 }
@@ -151,40 +155,7 @@ extension PlaceListViewController {
 extension PlaceListViewController {
     
     private func configureUI() {
-        tableView.backgroundColor = .clear
-        tableView.dataSource = self
-        tableView.prefetchDataSource = self
-        tableView.delegate = self
-        tableView.register(PlaceCell.self, forCellReuseIdentifier: PlaceCell.identifier)
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 300
-        tableView.separatorStyle = .none
-
-        removeBackgroundAndDivider()
         configureNaviBar()
-        
-        view.backgroundColor = .white
-        headerView.backgroundColor = .white
-        segmentIndicator.backgroundColor = .black
-        
-        segmentedControl.backgroundColor = .clear
-        segmentedControl.tintColor = .clear
-        segmentedControl.apportionsSegmentWidthsByContent = true
-        segmentedControl.selectedSegmentIndex = 0
-        
-        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 26, weight: .bold), NSAttributedString.Key.foregroundColor: UIColor.lightGray], for: .normal)
-        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 26, weight: .bold), NSAttributedString.Key.foregroundColor: UIColor.black], for: .selected)
-        segmentedControl.addTarget(self, action: #selector(indexChanged), for: .valueChanged)
-        
-        let imageConfiguration = UIImage.SymbolConfiguration(weight: .semibold)
-        let questionMarkImage = UIImage(systemName: "questionmark.circle", withConfiguration: imageConfiguration)
-        
-        questionButton.setImage(questionMarkImage, for: .normal)
-        questionButton.tintColor = .zestyColor(.gray54)
-        
-        let sidePlusImage = UIImage(.btn_side_plus)
-        addPlaceButton.setImage(sidePlusImage, for: .normal)
-        addPlaceButton.addTarget(self, action: #selector(addPlaceButtonTapped), for: .touchUpInside)
     }
     
     private func configureNaviBar() {
@@ -201,56 +172,6 @@ extension PlaceListViewController {
         navigationItem.hidesBackButton = true
         
         navigationController?.navigationBar.tintColor = .black
-    }
-    
-    private func removeBackgroundAndDivider() {
-        let removeBackgroundDivider = UIImage()
-        segmentedControl.setBackgroundImage(removeBackgroundDivider, for: .normal, barMetrics: .default)
-        segmentedControl.setBackgroundImage(removeBackgroundDivider, for: .selected, barMetrics: .default)
-        segmentedControl.setDividerImage(removeBackgroundDivider, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
-    }
-    
-    private func createLayout() {
-        view.addSubviews([headerView, tableView])
-        headerView.addSubviews([segmentedControl, segmentIndicator, questionButton, addPlaceButton])
-        
-        headerView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(85)
-        }
-        
-        segmentedControl.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.left.equalToSuperview().inset(20)
-            make.width.equalTo(172)
-            make.height.equalTo(32)
-        }
-        
-        segmentIndicator.snp.makeConstraints { make in
-            make.top.equalTo(segmentedControl.snp.bottom).offset(3)
-            make.height.equalTo(3)
-            make.width.equalTo(20)
-            make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(segmentedControl.numberOfSegments)
-        }
-        
-        questionButton.snp.makeConstraints { make in
-            make.left.equalTo(segmentedControl.snp.right)
-            make.top.equalTo(segmentedControl.snp.top)
-            make.width.equalTo(21)
-            make.height.equalTo(21)
-        }
-        
-        addPlaceButton.snp.makeConstraints { make in
-            make.centerY.right.equalToSuperview()
-            make.width.equalTo(70)
-            make.height.equalTo(65)
-        }
-        
-        tableView.snp.makeConstraints { make in
-            make.top.equalTo(headerView.snp.bottom)
-            make.horizontalEdges.bottom.equalToSuperview()
-        }
     }
     
 }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -118,6 +118,7 @@ extension PlaceListViewController {
         let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: sectionHeaderSize,
                                                                         elementKind: headerType,
                                                                         alignment: .topLeading)
+        sectionHeader.pinToVisibleBounds = true
         section.boundarySupplementaryItems = [sectionHeader]
         
         return UICollectionViewCompositionalLayout(section: section)

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -107,7 +107,6 @@ extension PlaceListViewController {
 
     private func createLayout() -> UICollectionViewLayout {
         let section: NSCollectionLayoutSection
-        let margin: CGFloat = 10
         
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(90))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -120,7 +119,6 @@ extension PlaceListViewController {
                                                                         elementKind: headerType,
                                                                         alignment: .topLeading)
         section.boundarySupplementaryItems = [sectionHeader]
-        section.contentInsets = NSDirectionalEdgeInsets(top: margin, leading: margin, bottom: margin, trailing: margin)
         
         return UICollectionViewCompositionalLayout(section: section)
     }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -39,11 +39,10 @@ final class PlaceListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        configureUI()
-//        configureHierarchy()
-//        configureDataSource()
-//        applyInitialSnapShot()
-//        bind()
+        configureUI()
+        configureHierarchy()
+        configureDataSource()
+        bind()
     }
     
     // MARK: - Function
@@ -51,10 +50,9 @@ final class PlaceListViewController: UIViewController {
     private func bind() {
         viewModel.$result
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] places in
+            .sink { [weak self] placeList in
                 guard let self = self else { return }
-                self.snapshot.appendItems(places)
-                self.dataSource.apply(self.snapshot)
+                self.applySnapshot(with: placeList)
             }
             .store(in: &cancelBag)
     }
@@ -101,8 +99,9 @@ extension PlaceListViewController {
     private func configureHierarchy() {
         collectionView = UICollectionView(frame: view.frame, collectionViewLayout: createLayout())
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        collectionView.backgroundColor = .clear
+        collectionView.backgroundColor = .systemBackground
         collectionView.delegate = self
+        collectionView.prefetchDataSource = self
         view.addSubview(collectionView)
     }
 
@@ -144,9 +143,10 @@ extension PlaceListViewController {
         }
     }
 
-    private func applyInitialSnapShot() {
+    private func applySnapshot(with items: [Place]) {
+        snapshot.deleteAllItems()
         snapshot.appendSections([1])
-        snapshot.appendItems([], toSection: 1)
+        snapshot.appendItems(items, toSection: 1)
         dataSource.apply(snapshot)
     }
 

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -76,7 +76,15 @@ extension PlaceListViewController: UICollectionViewDataSourcePrefetching, UIColl
 
 // MARK: - UI function
 
-extension PlaceListViewController {
+protocol AddPlaceDelegate: AnyObject {
+    func addPlaceButtonTapped()
+}
+
+extension PlaceListViewController: AddPlaceDelegate {
+    
+    func addPlaceButtonTapped() {
+        navigationController?.pushViewController(AddPlaceSearchViewController(viewModel: AddPlaceSearchViewModel()), animated: true)
+    }
     
     @objc func searchButtonTapped() {
         // TODO: 검색뷰 완성 시 연결
@@ -132,6 +140,7 @@ extension PlaceListViewController {
         let headerRegisteration = SupplymentaryViewRegistration(elementKind: headerType) { [weak self] supplementaryView, _, _ in
             guard let self = self else { return }
             supplementaryView.viewModel = self.viewModel
+            supplementaryView.addPlaceDelegate = self
         }
         
         dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
@@ -51,6 +51,7 @@ extension ReviewPageView {
         configureGradientView()
         
         reviewImageView.contentMode = .scaleAspectFill
+        menuLabel.numberOfLines = 1
         menuLabel.font = .preferredFont(forTextStyle: .footnote)
         menuLabel.textColor = .zestyColor(.whiteEBEBF5)
         menuLabel.layer.opacity = 0.6
@@ -64,13 +65,13 @@ extension ReviewPageView {
         }
         
         gradientView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
-            $0.height.equalTo(58)
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.top.equalTo(menuLabel.snp.top).offset(40)
         }
         
         menuLabel.snp.makeConstraints {
-            $0.left.equalToSuperview().inset(20)
+            $0.leading.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(80)
             $0.bottom.equalToSuperview()
         }
     }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
@@ -23,7 +23,6 @@ final class ReviewPageView: UIView {
         super.init(frame: frame)
         configure()
         createLayout()
-        setUp(with: Review.mockData[0])
     }
 
     required init?(coder: NSCoder) {
@@ -66,7 +65,7 @@ extension ReviewPageView {
         gradientView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
-            $0.height.greaterThanOrEqualTo(58)
+            $0.height.equalTo(58)
         }
         
         menuLabel.snp.makeConstraints {

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
@@ -43,6 +43,7 @@ extension ReviewPageView {
     
     func setEmptyView() {
         reviewImageView.image = UIImage(.img_categoryfriends)
+        gradientView.isHidden = true
     }
     
     private func configure() {

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
@@ -58,7 +58,7 @@ extension SegmentHeaderView {
             }
         } else {
             viewModel.placeType = .whole
-            segmentIndicator.snp.makeConstraints { make in
+            segmentIndicator.snp.remakeConstraints { make in
                 make.top.equalTo(segmentedControl.snp.bottom).offset(3)
                 make.height.equalTo(3)
                 make.width.equalTo(20)

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
@@ -1,0 +1,162 @@
+//
+//  SegmentHeaderView.swift
+//  App
+//
+//  Created by 리아 on 2022/11/01.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+final class SegmentHeaderView: UICollectionReusableView {
+    
+    // MARK: - Properties
+    var viewModel = PlaceListViewModel()
+    
+    private let segmentIndicator = UIView()
+    private let segmentedControl = UISegmentedControl(items: ["전체", "선정맛집"])
+    
+    private let questionButton = UIButton()
+    private let addPlaceButton = UIButton()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        createLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: - UI Functions
+
+extension SegmentHeaderView {
+    
+    @objc func addPlaceButtonTapped() {
+        viewModel.addPlaceButtonTapped()
+    }
+    
+    @objc func indexChanged(_ sender: UISegmentedControl) {
+        let numberOfSegments = CGFloat(segmentedControl.numberOfSegments)
+        let selectedIndex = CGFloat(sender.selectedSegmentIndex)
+        let titlecount = CGFloat((segmentedControl.titleForSegment(at: sender.selectedSegmentIndex)!.count))
+        
+        if selectedIndex == 1 {
+            viewModel.placeType = .hot
+            segmentIndicator.snp.remakeConstraints { (make) in
+                make.top.equalTo(segmentedControl.snp.bottom).offset(3)
+                make.height.equalTo(3)
+                make.width.equalTo(titlecount * 11)
+                make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(numberOfSegments / CGFloat(2.58 + CGFloat(selectedIndex-1.0)*2.0))
+            }
+        } else {
+            viewModel.placeType = .whole
+            segmentIndicator.snp.makeConstraints { make in
+                make.top.equalTo(segmentedControl.snp.bottom).offset(3)
+                make.height.equalTo(3)
+                make.width.equalTo(20)
+                make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(segmentedControl.numberOfSegments)
+            }
+        }
+
+        UIView.animate(withDuration: 0.3) {
+            self.layoutIfNeeded()
+            self.segmentIndicator.transform = CGAffineTransform(scaleX: 1.1, y: 1)
+        } completion: { _ in
+            UIView.animate(withDuration: 0.4, animations: {
+                self.segmentIndicator.transform = CGAffineTransform.identity
+            })
+        }
+    }
+
+}
+
+extension SegmentHeaderView {
+    
+    private func configureUI() {
+        backgroundColor = .white
+        
+        removeBackgroundAndDivider()
+        segmentIndicator.backgroundColor = .black
+        
+        segmentedControl.backgroundColor = .clear
+        segmentedControl.tintColor = .clear
+        segmentedControl.apportionsSegmentWidthsByContent = true
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 26, weight: .bold),
+                                                 NSAttributedString.Key.foregroundColor: UIColor.lightGray],
+                                                for: .normal)
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 26, weight: .bold),
+                                                 NSAttributedString.Key.foregroundColor: UIColor.black],
+                                                for: .selected)
+        segmentedControl.addTarget(self, action: #selector(indexChanged), for: .valueChanged)
+        
+        let imageConfiguration = UIImage.SymbolConfiguration(weight: .semibold)
+        let questionMarkImage = UIImage(systemName: "questionmark.circle", withConfiguration: imageConfiguration)
+        questionButton.setImage(questionMarkImage, for: .normal)
+        questionButton.tintColor = .zestyColor(.gray54)
+        
+        let sidePlusImage = UIImage(.btn_side_plus)
+        addPlaceButton.setImage(sidePlusImage, for: .normal)
+        addPlaceButton.addTarget(self, action: #selector(addPlaceButtonTapped), for: .touchUpInside)
+    }
+    
+    private func removeBackgroundAndDivider() {
+        let removeBackgroundDivider = UIImage()
+        segmentedControl.setBackgroundImage(removeBackgroundDivider, for: .normal, barMetrics: .default)
+        segmentedControl.setBackgroundImage(removeBackgroundDivider, for: .selected, barMetrics: .default)
+        segmentedControl.setDividerImage(removeBackgroundDivider, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
+    }
+
+    private func createLayout() {
+        addSubviews([segmentedControl, segmentIndicator, questionButton, addPlaceButton])
+        
+        segmentedControl.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.left.equalToSuperview().inset(20)
+            $0.width.equalTo(172)
+            $0.height.equalTo(32)
+        }
+        
+        segmentIndicator.snp.makeConstraints {
+            $0.top.equalTo(segmentedControl.snp.bottom).offset(3)
+            $0.height.equalTo(3)
+            $0.width.equalTo(20)
+            $0.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(segmentedControl.numberOfSegments)
+        }
+        
+        questionButton.snp.makeConstraints {
+            $0.left.equalTo(segmentedControl.snp.right)
+            $0.top.equalTo(segmentedControl.snp.top)
+            $0.width.equalTo(21)
+            $0.height.equalTo(21)
+        }
+        
+        addPlaceButton.snp.makeConstraints {
+            $0.centerY.right.equalToSuperview()
+            $0.width.equalTo(70)
+            $0.height.equalTo(65)
+        }
+    }
+
+}
+
+// MARK: - Previews
+
+#if DEBUG
+import SwiftUI
+
+struct SegmentHeaderPreview: PreviewProvider {
+    
+    static var previews: some View {
+        SegmentHeaderView().toPreview()
+    }
+    
+}
+#endif

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
@@ -85,6 +85,8 @@ extension SegmentHeaderView {
         
         removeBackgroundAndDivider()
         segmentIndicator.backgroundColor = .black
+        segmentIndicator.layer.cornerRadius = 1
+        segmentIndicator.layer.masksToBounds = true
         
         segmentedControl.backgroundColor = .clear
         segmentedControl.tintColor = .clear

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
@@ -13,6 +13,7 @@ final class SegmentHeaderView: UICollectionReusableView {
     
     // MARK: - Properties
     var viewModel = PlaceListViewModel()
+    weak var addPlaceDelegate: AddPlaceDelegate!
     
     private let segmentIndicator = UIView()
     private let segmentedControl = UISegmentedControl(items: ["전체", "선정맛집"])
@@ -39,7 +40,7 @@ final class SegmentHeaderView: UICollectionReusableView {
 extension SegmentHeaderView {
     
     @objc func addPlaceButtonTapped() {
-        viewModel.addPlaceButtonTapped()
+        addPlaceDelegate.addPlaceButtonTapped()
     }
     
     @objc func indexChanged(_ sender: UISegmentedControl) {

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/SegmentHeaderView.swift
@@ -12,8 +12,8 @@ import SnapKit
 final class SegmentHeaderView: UICollectionReusableView {
     
     // MARK: - Properties
-    var viewModel = PlaceListViewModel()
-    weak var addPlaceDelegate: AddPlaceDelegate!
+    weak var viewModel: PlaceListViewModel?
+    weak var addPlaceDelegate: AddPlaceDelegate?
     
     private let segmentIndicator = UIView()
     private let segmentedControl = UISegmentedControl(items: ["전체", "선정맛집"])
@@ -40,7 +40,7 @@ final class SegmentHeaderView: UICollectionReusableView {
 extension SegmentHeaderView {
     
     @objc func addPlaceButtonTapped() {
-        addPlaceDelegate.addPlaceButtonTapped()
+        addPlaceDelegate?.addPlaceButtonTapped()
     }
     
     @objc func indexChanged(_ sender: UISegmentedControl) {
@@ -49,7 +49,7 @@ extension SegmentHeaderView {
         let titlecount = CGFloat((segmentedControl.titleForSegment(at: sender.selectedSegmentIndex)!.count))
         
         if selectedIndex == 1 {
-            viewModel.placeType = .hot
+            viewModel?.placeType = .hot
             segmentIndicator.snp.remakeConstraints { (make) in
                 make.top.equalTo(segmentedControl.snp.bottom).offset(3)
                 make.height.equalTo(3)
@@ -57,7 +57,7 @@ extension SegmentHeaderView {
                 make.centerX.equalTo(segmentedControl.snp.centerX).dividedBy(numberOfSegments / CGFloat(2.58 + CGFloat(selectedIndex-1.0)*2.0))
             }
         } else {
-            viewModel.placeType = .whole
+            viewModel?.placeType = .whole
             segmentIndicator.snp.remakeConstraints { make in
                 make.top.equalTo(segmentedControl.snp.bottom).offset(3)
                 make.height.equalTo(3)

--- a/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
@@ -102,9 +102,5 @@ extension PlaceListViewModel: ErrorMapper {
             }
             .store(in: &self.cancelBag)
     }
-    
-    // TODO: 맛집 등록하기 버튼 눌렀을 때 뷰컨 반응 구현하기
-    func addPlaceButtonTapped() {
-//        navigationController?.pushViewController(AddPlaceSearchViewController(viewModel: AddPlaceSearchViewModel()), animated: true)
-    }
+
 }

--- a/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
@@ -126,4 +126,8 @@ extension PlaceListViewModel: ErrorMapper {
             .store(in: &self.cancelBag)
     }
     
+    // TODO: 맛집 등록하기 버튼 눌렀을 때 뷰컨 반응 구현하기
+    func addPlaceButtonTapped() {
+//        navigationController?.pushViewController(AddPlaceSearchViewController(viewModel: AddPlaceSearchViewModel()), animated: true)
+    }
 }

--- a/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
@@ -13,30 +13,35 @@ import Network
 class PlaceListViewModel {
     
     // MARK: - Properties
-    
-    enum PlaceType {
-        case whole
-        case hot
-    }
-    
+
     private let useCase: PlaceListUseCase
     private var cancelBag = Set<AnyCancellable>()
+    
+    class Section {
+        let type: PlaceType
+        var lastIndex: Int = -1
+        var cursor: Int = 1
+        var placeList: [Place] = []
+        
+        init(type: PlaceType) {
+            self.type = type
+        }
+    }
     
     // Input
     @Published var placeType: PlaceType = .whole
     
     // Output
-    @Published private var wholePage: Int = 1
-    @Published private var hotPage: Int = 1
     @Published var result: [Place] = []
-    private var wholeResult: [Place] = []
-    private var hotResult: [Place] = []
+    private var wholePlace = Section(type: .whole)
+    private var hotPlace = Section(type: .hot)
     let isRegisterFail = PassthroughSubject<String, Never>() // alert 용
     
     // MARK: - LifeCycle
     
     init(useCase: PlaceListUseCase = PlaceListUseCase()) {
         self.useCase = useCase
+        prefetch(at: [1])
         bind()
     }
     
@@ -47,80 +52,52 @@ class PlaceListViewModel {
 extension PlaceListViewModel: ErrorMapper {
     
     func prefetch(at rows: [Int]) {
-        let unit = 10
+        let section: Section
         
         switch placeType {
         case .whole:
-            for row in rows {
-                if (wholePage - 1) * unit <= row && (wholePage * unit) > row {
-                    wholePage += 1
-                    break
-                }
-            }
+            section = wholePlace
         case .hot:
-            for row in rows {
-                if (hotPage - 1) * unit <= row && (hotPage * unit) > row {
-                    hotPage += 1
-                    break
-                }
-            }
+            section = hotPlace
         }
-
+        
+        // fetch 여부는 해당 row가 이미 불려진 row인지로 판단
+        for row in rows where row >= section.lastIndex {
+            useCase.fetchPlaceList(with: section.cursor,
+                                   type: section.type)
+                .sink { [weak self] error in
+                    guard let self = self else { return }
+                    
+                    switch error {
+                    case .failure(let error):
+                        let errorMessage = self.errorMessage(for: error)
+                        self.isRegisterFail.send(errorMessage)
+                    case .finished: break
+                    }
+                } receiveValue: { [weak self] placeList in
+                    guard let self = self, !placeList.isEmpty else { return }
+                    
+                    // fetch된 데이터 업데이트
+                    section.placeList += placeList
+                    section.lastIndex += placeList.count
+                    // 서버에 요청할 인덱스 = 가장 마지막 데이터의 placeID + 1
+                    section.cursor = section.placeList[section.lastIndex].id + 1
+                    self.result = section.placeList
+                }
+                .store(in: &self.cancelBag)
+            break
+        }
     }
     
     private func bind() {
-        $hotPage
-            .sink { [weak self] currentPage in
-                guard let self = self else { return }
-                
-                self.useCase.fetchHotPlaceList(with: currentPage)
-                    .sink { error in
-                        switch error {
-                        case .failure(let error):
-                            print("🐞: \(error)")
-                            let errorMessage = self.errorMessage(for: error)
-                            self.isRegisterFail.send(errorMessage)
-                        case .finished: break
-                        }
-                    } receiveValue: { [weak self] placeList in
-                        guard let self = self else { return }
-                        
-                        self.hotResult += placeList
-                        self.result = self.hotResult
-                    }
-                    .store(in: &self.cancelBag)
-            }
-            .store(in: &cancelBag)
-        
-        $wholePage
-            .sink { [weak self] currentPage in
-                guard let self = self else { return }
-                
-                self.useCase.fetchPlaceList(with: currentPage)
-                    .sink { error in
-                        switch error {
-                        case .failure(let error):
-                            let errorMessage = self.errorMessage(for: error)
-                            self.isRegisterFail.send(errorMessage)
-                        case .finished: break
-                        }
-                    } receiveValue: { [weak self] placeList in
-                        guard let self = self else { return }
-                        self.wholeResult += placeList
-                        self.result = self.wholeResult
-                    }
-                    .store(in: &self.cancelBag)
-            }
-            .store(in: &cancelBag)
-        
         $placeType
             .sink { [weak self] type in
                 guard let self = self else { return }
                 switch type {
                 case .whole:
-                    self.result = self.wholeResult
+                    self.result = self.wholePlace.placeList
                 case .hot:
-                    self.result = self.hotResult
+                    self.result = self.hotPlace.placeList
                 }
             }
             .store(in: &self.cancelBag)

--- a/Projects/DesignSystem/Resources/Assets.xcassets/img_reviewfriends/img_reviewfriends_bad.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Assets.xcassets/img_reviewfriends/img_reviewfriends_bad.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "bad.svg",
+      "filename" : "Bad.svg",
       "idiom" : "universal"
     }
   ],

--- a/Projects/DesignSystem/Resources/Assets.xcassets/img_reviewfriends/img_reviewfriends_bad.imageset/Contents.json
+++ b/Projects/DesignSystem/Resources/Assets.xcassets/img_reviewfriends/img_reviewfriends_bad.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "Bad.svg",
+      "filename" : "bad.svg",
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] cell의 개수를 몰라도 되는 Diffable Datasource 방식으로 변경
- [x] 테이블뷰에서 컬렉션뷰로 리팩토링
- [x] 디퍼블 전환에 따른, header view 분리, 헤더 고정
- [x] 맛집 추가 버튼 누를 시, 맛집 추가 뷰로 넘어가게 함
- [x] cell의 이미지 영역도 touch시 다음 화면으로 넘어가게 버그 수정
- [x] Xcode command 창을 더럽히던 레이아웃 깨짐 이슈 해결
- [x] 서버 api에 따라, 마지막 index를 기준으로 prefetch 하도록 수정
- [x] 마구잡이 fetch 코드 개선 

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="">|<img width="250" src="https://user-images.githubusercontent.com/73650994/199711906-8fc8a01d-d18b-42ff-92a0-c49a8acf529b.gif">|


## 리뷰포인트
- @Chaeho-Min 헤더 고정하니까 뭔가 네비게이션 바랑 안 어울리는 것 같고 이상해요...
 한 번 봐주시면 감사하겠습니다 🙏🏻

<img width="536" alt="image" src="https://user-images.githubusercontent.com/73650994/199696240-d6572c2a-d83f-441e-8096-ec83d052d687.png">

- PlaceCell.swift 에서 스크롤뷰를 감싸고 있는 `containerView`에 보라색 전구 아이콘이 뜹니다..
무슨 의미이고, 어떻게 해결할 지 몰라 방치하고 있습니다.
보라색 느낌표는 레이아웃 이슈일 때인데, 아이콘이 다른 걸 보아 일단 그 이슈는 아닌 것 같습니다.

# Reference
- [Cell 안의 ScrollView가 cell의 didSelectAt 이벤트를 먹을 때 해결하는 법](https://stackoverflow.com/questions/14298650/uicollectionviewcell-with-uiscrollview-cancels-didselectitematindexpath)

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max
