### PR TITLE
[Design] 대학교 이메일 인증 뷰 UI

### DIFF
--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -70,7 +70,7 @@ final class VerifingCodeViewController: UIViewController {
         
         toastLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(view.snp.top).offset(-50)
+            make.bottom.equalTo(view.snp.top)
             make.width.equalTo(173)
             make.height.equalTo(50)
         }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -79,8 +79,8 @@ final class VerifingCodeViewController: UIViewController {
         }, completion: { _ in
             toastLabel.removeFromSuperview()
         })
-        
     }
+    
 }
 
 // MARK: - UI Function

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -14,7 +14,7 @@ import SnapKit
 final class VerifingCodeViewController: UIViewController {
     
     // MARK: - Properties
-    private let cancelBag = Set<AnyCancellable>()
+    private var cancelBag = Set<AnyCancellable>()
     
     private lazy var titleView = MainTitleView(title: "이메일로 받은 코드를\n알려주세요", subtitle: "\(userEmail)", hasSymbol: true)
     
@@ -26,11 +26,11 @@ final class VerifingCodeViewController: UIViewController {
     private let resendLabel = UILabel()
     private let resendEamilButton = UIButton(type: .custom)
     
-    private let arrowButton = ArrowButton(initialDisable: true)
+    private let arrowButton = ArrowButton(initialDisable: false)
     
     // TODO: ViewModel로 옮길 것들입니다
     let userEmail = "mingming@pos.idserve.net"
-    var isArrowButtonHidden: Bool = true
+    var isArrowButtonHidden: Bool = false
     var isCodeValid: Bool = true
     var userInputCode: String = ""
     var timer = "03:00"
@@ -41,6 +41,7 @@ final class VerifingCodeViewController: UIViewController {
         super.viewDidLoad()
         configureUI()
         createLayout()
+        bindUI()
     }
     
     // MARK: - Function
@@ -79,6 +80,24 @@ final class VerifingCodeViewController: UIViewController {
         }, completion: { _ in
             toastLabel.removeFromSuperview()
         })
+    }
+    
+}
+
+// MARK: Bind Function
+
+extension VerifingCodeViewController {
+    
+    private func bindUI() {
+        NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
+            .sink { [weak self] notification in
+                guard let self = self else { return }
+                guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+                let endFrameHeight = endFrame.cgRectValue.height
+                self.remakeConstraintsByKeyboard(keybordHeight: endFrameHeight)
+                self.view.layoutIfNeeded()
+            }
+            .store(in: &cancelBag)
     }
     
 }
@@ -149,7 +168,22 @@ extension VerifingCodeViewController {
         
         arrowButton.snp.makeConstraints { make in
             make.right.equalToSuperview().inset(20)
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(20)
+            make.bottom.equalTo(view.snp.bottom).offset(-20)
+        }
+    }
+    
+    private func remakeConstraintsByKeyboard(keybordHeight: CGFloat? = nil) {
+        guard let keybordHeight = keybordHeight else {
+            arrowButton.snp.makeConstraints { make in
+                make.right.equalToSuperview().inset(20)
+                make.bottom.equalTo(view.snp.bottom).offset(-20)
+            }
+            return
+        }
+        
+        arrowButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().inset(20)
+            make.bottom.equalTo(view.snp.bottom).offset(-keybordHeight-20)
         }
     }
     

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -30,7 +30,7 @@ final class VerifingCodeViewController: UIViewController {
     
     // TODO: ViewModel로 옮길 것들입니다
     let userEmail = "mingming@pos.idserve.net"
-    var isArrowButtonHidden: Bool = false
+    var isArrowButtonHidden: Bool = true
     var isCodeValid: Bool = true
     var userInputCode: String = ""
     var timer = "03:00"
@@ -114,6 +114,7 @@ extension VerifingCodeViewController {
         
         warningMessage.text = "잘못된 코드예요."
         warningMessage.isHidden = isCodeValid
+        warningMessage.textColor = .zestyColor(.point)
         
         timerLabel.text = timer
         

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -183,12 +183,12 @@ extension VerifingCodeViewController {
         guard let keyboardEndFrameHeight = self.keyboardEndFrameHeight else { return }
         switch state {
         case .hide:
-            arrowButton.snp.makeConstraints { make in
+            arrowButton.snp.remakeConstraints { make in
                 make.right.equalToSuperview().inset(20)
                 make.bottom.equalTo(view.snp.bottom).offset(-20)
             }
         case .show:
-            arrowButton.snp.makeConstraints { make in
+            arrowButton.snp.remakeConstraints { make in
                 make.right.equalToSuperview().inset(20)
                 make.bottom.equalTo(view.snp.bottom).offset(-keyboardEndFrameHeight-20)
             }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -74,7 +74,7 @@ final class VerifingCodeViewController: UIViewController {
             toastLabel.center.y = 100
         })
         
-        UIView.animate(withDuration: 0.3, delay: 3, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: 0.3, delay: 2.5, options: .curveEaseIn, animations: {
             toastLabel.center.y = 0
         }, completion: { _ in
             toastLabel.removeFromSuperview()

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -61,7 +61,7 @@ final class VerifingCodeViewController: UIViewController {
         toastLabel.textColor = .white
         toastLabel.font = .systemFont(ofSize: 16.0, weight: .regular)
         toastLabel.textAlignment = .center
-        toastLabel.text = "메일을  다시 보냈어요"
+        toastLabel.text = "메일을 다시 보냈어요"
         toastLabel.layer.cornerRadius = 25
         toastLabel.clipsToBounds  =  true
         toastLabel.numberOfLines = 0

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import UIKit
+import DesignSystem
 import SnapKit
 
 final class VerifingCodeViewController: UIViewController {
@@ -15,6 +16,24 @@ final class VerifingCodeViewController: UIViewController {
     // MARK: - Properties
     private let cancelBag = Set<AnyCancellable>()
     
+    private lazy var titleView = MainTitleView(title: "이메일로 받은 코드를\n알려주세요", subtitle: "\(userEmail)", hasSymbol: true)
+    
+    private let warningMessage = UILabel()
+    private let otpStackView = OTPStackView()
+    private let timerLabel = UILabel()
+    
+    private let resendStackView = UIStackView()
+    private let resendLabel = UILabel()
+    private let resendEamilButton = UIButton(type: .custom)
+    
+    private let arrowButton = ArrowButton(initialDisable: true)
+    
+    // TODO: ViewModel로 옮길 것들입니다
+    let userEmail = "mingming@pos.idserve.net"
+    var isArrowButtonHidden: Bool = true
+    var isCodeValid: Bool = true
+    var userInputCode: String = ""
+    var timer = "03:00"
     
     // MARK: - LifeCycle
     
@@ -28,29 +47,83 @@ final class VerifingCodeViewController: UIViewController {
     
 }
 
-
 // MARK: - UI Function
 
 extension VerifingCodeViewController {
     
     private func configureUI() {
+        warningMessage.text = "잘못된 코드에요."
+        warningMessage.isHidden = isCodeValid
         
+        timerLabel.text = timer
+        
+        resendStackView.spacing = 10
+        resendStackView.axis = .horizontal
+        resendStackView.distribution = .fill
+        resendStackView.alignment = .fill
+        
+        resendLabel.text = "메일이 오지 않았나요?"
+        resendLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        resendLabel.numberOfLines = 0
+        
+        resendEamilButton.setTitle("다시 보내기", for: .normal)
+        resendEamilButton.setTitleColor(.label, for: .normal)
+        resendEamilButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .bold)
+        
+        arrowButton.isHidden = isArrowButtonHidden
+        arrowButton.startIndicator()
     }
     
     private func createLayout() {
+        view.addSubviews([titleView, warningMessage, otpStackView, timerLabel, resendStackView, arrowButton])
+        resendStackView.addArrangedSubviews([resendLabel, resendEamilButton])
         
+        titleView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.horizontalEdges.equalToSuperview()
+        }
+        
+        warningMessage.snp.makeConstraints { make in
+            make.top.equalTo(titleView.snp.bottom).offset(82)
+            make.centerX.equalToSuperview()
+        }
+        
+        otpStackView.snp.makeConstraints { make in
+            make.top.equalTo(warningMessage.snp.bottom).offset(15)
+            make.height.equalTo(50)
+            make.width.equalTo(190)
+            make.centerX.equalToSuperview()
+        }
+        
+        timerLabel.snp.makeConstraints { make in
+            make.top.equalTo(otpStackView.snp.bottom).offset(15)
+            make.centerX.equalToSuperview()
+        }
+        
+        resendStackView.snp.makeConstraints { make in
+            make.top.equalTo(timerLabel.snp.bottom).offset(43)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        arrowButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().inset(20)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(20)
+        }
     }
     
 }
 
-/*
 // MARK: - Previews
 
-extension VerifingCodePreview: PreviewProvider {
+#if DEBUG
+import SwiftUI
+
+struct VerifingCodePreview: PreviewProvider {
     
     static var previews: some View {
         VerifingCodeViewController().toPreview()
     }
     
 }
-*/
+#endif

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -45,6 +45,42 @@ final class VerifingCodeViewController: UIViewController {
     
     // MARK: - Function
     
+    @objc func resendButtonTapped() {
+        print("버튼 눌림")
+        showToastMessage()
+    }
+    
+    private func showToastMessage() {
+        let toastLabel = UILabel()
+        toastLabel.backgroundColor = .black
+        toastLabel.textColor = .white
+        toastLabel.font = .systemFont(ofSize: 16.0, weight: .regular)
+        toastLabel.textAlignment = .center
+        toastLabel.text = "메일을  다시 보냈어요"
+        toastLabel.layer.cornerRadius = 25
+        toastLabel.clipsToBounds  =  true
+        toastLabel.numberOfLines = 0
+        
+        self.view.addSubview(toastLabel)
+        
+        toastLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(view.snp.top).offset(-50)
+            make.width.equalTo(173)
+            make.height.equalTo(50)
+        }
+        
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut, animations: {
+            toastLabel.center.y = 100
+        })
+        
+        UIView.animate(withDuration: 0.3, delay: 3, options: .curveEaseIn, animations: {
+            toastLabel.center.y = 0
+        }, completion: { _ in
+            toastLabel.removeFromSuperview()
+        })
+        
+    }
 }
 
 // MARK: - UI Function
@@ -52,7 +88,9 @@ final class VerifingCodeViewController: UIViewController {
 extension VerifingCodeViewController {
     
     private func configureUI() {
-        warningMessage.text = "잘못된 코드에요."
+        view.backgroundColor = .white
+        
+        warningMessage.text = "잘못된 코드예요."
         warningMessage.isHidden = isCodeValid
         
         timerLabel.text = timer
@@ -69,7 +107,7 @@ extension VerifingCodeViewController {
         resendEamilButton.setTitle("다시 보내기", for: .normal)
         resendEamilButton.setTitleColor(.label, for: .normal)
         resendEamilButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .bold)
-        
+        resendEamilButton.addTarget(self, action: #selector(resendButtonTapped), for: .touchUpInside)
         arrowButton.isHidden = isArrowButtonHidden
         arrowButton.startIndicator()
     }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -1,0 +1,56 @@
+//
+//  VerifingCodeViewController.swift
+//  App
+//
+//  Created by 김태호 on 2022/11/02.
+//  Copyright (c) 2022 com.zesty. All rights reserved.
+//
+
+import Combine
+import UIKit
+import SnapKit
+
+final class VerifingCodeViewController: UIViewController {
+    
+    // MARK: - Properties
+    private let cancelBag = Set<AnyCancellable>()
+    
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        createLayout()
+    }
+    
+    // MARK: - Function
+    
+}
+
+
+// MARK: - UI Function
+
+extension VerifingCodeViewController {
+    
+    private func configureUI() {
+        
+    }
+    
+    private func createLayout() {
+        
+    }
+    
+}
+
+/*
+// MARK: - Previews
+
+extension VerifingCodePreview: PreviewProvider {
+    
+    static var previews: some View {
+        VerifingCodeViewController().toPreview()
+    }
+    
+}
+*/

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -90,6 +90,9 @@ extension VerifingCodeViewController {
     private func configureUI() {
         view.backgroundColor = .white
         
+        navigationController?.navigationBar.tintColor = .label
+        navigationController?.navigationBar.topItem?.title = ""
+        
         warningMessage.text = "잘못된 코드예요."
         warningMessage.isHidden = isCodeValid
         

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -16,6 +16,8 @@ final class VerifingCodeViewController: UIViewController {
     // MARK: - Properties
     private var cancelBag = Set<AnyCancellable>()
     
+    private let isSE: Bool = UIScreen.main.isHeightLessThan670pt
+    
     private lazy var titleView = MainTitleView(title: "이메일로 받은 코드를\n알려주세요", subtitle: "\(userEmail)", hasSymbol: true)
     
     private let warningMessage = UILabel()
@@ -145,7 +147,7 @@ extension VerifingCodeViewController {
         }
         
         warningMessage.snp.makeConstraints { make in
-            make.top.equalTo(titleView.snp.bottom).offset(82)
+            make.top.equalTo(titleView.snp.bottom).offset(isSE ? 20 : 82)
             make.centerX.equalToSuperview()
         }
         

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
@@ -1,0 +1,21 @@
+//
+//  OTPStackView.swift
+//  App
+//
+//  Created by 김태호 on 2022/11/02.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import UIKit
+
+class OTPStackView: UIStackView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
@@ -7,15 +7,152 @@
 //
 
 import UIKit
+import DesignSystem
 
-class OTPStackView: UIStackView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
-
+protocol OTPDelegate: AnyObject {
+    func didChangeValidity(isValid: Bool)
 }
+
+final class OTPStackView: UIStackView {
+    
+    // MARK: - Properties
+    
+    weak var delegate: OTPDelegate?
+    
+    private let numberOfFields: Int = 4
+    private lazy var textFieldArray: [OTPTextField] = []
+    private var showWarningMessage: Bool = false
+    
+    private let textBackgroundColor = UIColor.zestyColor(.grayF6)
+    private var remainingStrStack: [String] = []
+    private var userTextInput: String = ""
+    
+    // MARK: - LifeCycle
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupStackView()
+        addOTPFields()
+    }
+    
+    // MARK: - Function
+    
+    private func checkForValidity() {
+        for fields in textFieldArray where fields.text == "" {
+            delegate?.didChangeValidity(isValid: false)
+            return
+        }
+        delegate?.didChangeValidity(isValid: true)
+    }
+    
+}
+
+// MARK: - UI Function
+
+extension OTPStackView {
+    
+    private final func setupStackView() {
+        backgroundColor = .clear
+        isUserInteractionEnabled = true
+        contentMode = .center
+        distribution = .fillEqually
+        spacing = 10
+    }
+    
+    private func setupTextField(_ textField: OTPTextField) {
+        addArrangedSubview(textField)
+        
+        textField.delegate = self
+        textField.backgroundColor = textBackgroundColor
+        textField.textAlignment = .center
+        textField.font = .systemFont(ofSize: 17, weight: .bold)
+        textField.textColor = .white
+        textField.layer.cornerRadius = 20
+        textField.layer.masksToBounds = true
+        textField.keyboardType = .numberPad
+        
+        textField.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.height.equalToSuperview()
+            make.width.equalTo(40)
+        }
+        
+    }
+    
+    private func addOTPFields() {
+        for index in 0..<numberOfFields {
+            let field = OTPTextField()
+            setupTextField(field)
+            textFieldArray.append(field)
+            
+            index != 0 ? (field.previousTextField = textFieldArray[index-1]) : (field.previousTextField = nil)
+            index != 0 ? (textFieldArray[index-1].nextTextField = field) : ()
+        }
+        textFieldArray[0].becomeFirstResponder()
+    }
+    
+    private func autoFillTextField(with string: String) {
+        remainingStrStack = string.reversed().compactMap { String($0) }
+        for textField in textFieldArray {
+            if let charToAdd = remainingStrStack.popLast() {
+                textField.text = String(charToAdd)
+                textField.backgroundColor = .black
+            } else {
+                break
+            }
+        }
+        checkForValidity()
+    }
+    
+}
+
+extension OTPStackView: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if showWarningMessage {
+            showWarningMessage = false
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        checkForValidity()
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let textField = textField as? OTPTextField else { return true }
+        if string.count > 1 {
+            autoFillTextField(with: string)
+            return false
+        } else {
+            if range.length == 0 {
+                if textField.nextTextField == nil {
+                    textField.text? = string
+                } else {
+                    textField.text? = string
+                    textField.nextTextField?.becomeFirstResponder()
+                }
+                textField.backgroundColor = .black
+                return false
+            }
+            textField.backgroundColor = .zestyColor(.grayF6)
+            return true
+        }
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+import SwiftUI
+
+struct OTPStackViewPreview: PreviewProvider {
+    
+    static var previews: some View {
+        OTPStackView().toPreview()
+    }
+    
+}
+#endif

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
@@ -120,6 +120,7 @@ extension OTPStackView {
 }
 
 extension OTPStackView: UITextFieldDelegate {
+    
     func textFieldDidBeginEditing(_ textField: UITextField) {
         if showWarningMessage {
             showWarningMessage = false
@@ -150,6 +151,7 @@ extension OTPStackView: UITextFieldDelegate {
             return true
         }
     }
+    
 }
 
 // MARK: - Previews

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
@@ -13,6 +13,8 @@ protocol OTPDelegate: AnyObject {
     func didChangeValidity(isValid: Bool)
 }
 
+/// 출처 : https://github.com/satyen95/iOS-OTPField/blob/master/OTPField/OTPField/OTPStackView.swift
+
 final class OTPStackView: UIStackView {
     
     // MARK: - Properties
@@ -137,7 +139,9 @@ extension OTPStackView: UITextFieldDelegate {
             autoFillTextField(with: string)
             return false
         } else {
-            if range.length == 0 {
+            if range.length == 0 && string == "" {
+                return false
+            } else if range.length == 0 {
                 if textField.nextTextField == nil {
                     textField.text? = string
                 } else {
@@ -147,7 +151,6 @@ extension OTPStackView: UITextFieldDelegate {
                 textField.backgroundColor = .black
                 return false
             }
-            textField.backgroundColor = .zestyColor(.grayF6)
             return true
         }
     }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPStackView.swift
@@ -49,6 +49,14 @@ final class OTPStackView: UIStackView {
         delegate?.didChangeValidity(isValid: true)
     }
     
+    func resetTextField() {
+        for textField in textFieldArray {
+            textField.text = ""
+            textField.backgroundColor = textBackgroundColor
+        }
+        textFieldArray[0].becomeFirstResponder()
+    }
+    
 }
 
 // MARK: - UI Function
@@ -74,6 +82,7 @@ extension OTPStackView {
         textField.layer.cornerRadius = 20
         textField.layer.masksToBounds = true
         textField.keyboardType = .numberPad
+        textField.tintColor = .clear
         
         textField.snp.makeConstraints { make in
             make.centerY.equalToSuperview()

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
@@ -1,0 +1,9 @@
+//
+//  OTPTextField.swift
+//  App
+//
+//  Created by 김태호 on 2022/11/02.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import Foundation

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
@@ -13,7 +13,14 @@ final class OTPTextField: UITextField {
     weak var nextTextField: OTPTextField?
     
     override public func deleteBackward() {
+        if let text = text, text.isEmpty {
+            previousTextField?.text = ""
+            previousTextField?.backgroundColor = .zestyColor(.grayF6)
+            previousTextField?.previousTextField?.becomeFirstResponder()
+        }
+        
         text = ""
+        backgroundColor = .zestyColor(.grayF6)
         previousTextField?.becomeFirstResponder()
     }
 }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/Views/OTPTextField.swift
@@ -6,4 +6,14 @@
 //  Copyright © 2022 com.zesty. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+final class OTPTextField: UITextField {
+    weak var previousTextField: OTPTextField?
+    weak var nextTextField: OTPTextField?
+    
+    override public func deleteBackward() {
+        text = ""
+        previousTextField?.becomeFirstResponder()
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/MainTitleView.swift
+++ b/Projects/DesignSystem/Sources/Component/MainTitleView.swift
@@ -21,11 +21,24 @@ public final class MainTitleView: UIView {
     public var subtitleLabel = UILabel()
     private let titleStackView = UIStackView()
     
-    public init(title: String = "", subtitle: String = "") {
+    public init(title: String = "", subtitle: String = "", hasSymbol: Bool = false) {
         super.init(frame: .zero)
         
         titleLabel.text = title
-        subtitleLabel.text = subtitle
+        
+        /// 출처 : https://stackoverflow.com/questions/58341042/is-it-possible-to-use-sf-symbols-outside-of-uiimage
+        if hasSymbol {
+            let symbolConfiguration = UIImage.SymbolConfiguration(font: .systemFont(ofSize: 15, weight: .regular))
+            let symbolImage = UIImage(systemName: "envelope", withConfiguration: symbolConfiguration)?.withRenderingMode(.alwaysTemplate)
+            let symbolTextAttachment = NSTextAttachment()
+            symbolTextAttachment.image = symbolImage
+            let attributedText = NSMutableAttributedString()
+            attributedText.append(NSAttributedString(attachment: symbolTextAttachment))
+            attributedText.append(NSAttributedString(string: " " + subtitle))
+            subtitleLabel.attributedText = attributedText
+        } else {
+            subtitleLabel.text = subtitle
+        }
         
         configureUI(subTitle: subtitle)
         createLayout(subtitle: subtitle)


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] OTPScreen 추가
- [x] 토스트 애니메이션 추가
- [x] MainTitleView의 subtitle에 SFsymbol 넣는 기능 추가

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|iPhone 13| 에러메세지 및 로딩|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/81206228/199717626-107bd194-9762-47a0-89ea-eaeb570b77ca.png">|<img width="250" src="https://user-images.githubusercontent.com/81206228/199717713-bcc47fa9-c583-4a99-8203-d8d883f12856.png">|
|iPhone 13 pro max| iPhone se 3|
|<img width="250" src="https://user-images.githubusercontent.com/81206228/199718029-52a5b191-8d08-4cf3-99be-e31aac5bfa87.png">|<img width="250" src="https://user-images.githubusercontent.com/81206228/199718190-1275b9ba-ea11-4413-a775-0910e2dac9df.png">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

### autolayout이 깨지는 현상 23da1b5703a30d291064ebeeb655efd852fdb9ea
```
(
    "<SnapKit.LayoutConstraint:0x6000009afc60@VerifingCodeViewController.swift#178 DesignSystem.ArrowButton:0x15770e900.bottom == UIView:0x158c08910.bottom - 20.0>",
    "<SnapKit.LayoutConstraint:0x60000098a1c0@VerifingCodeViewController.swift#193 DesignSystem.ArrowButton:0x15770e900.bottom == UIView:0x158c08910.bottom - 236.0>"
)
```
위와 같이 오토레이아웃이 깨지는 현상이 있습니다. 현재 코드는 고반의 NicknameInputViewController처럼 변경한 상태입니다.
레이아웃이 아예 그려지지 않는 것이 아니라 키보드 height가 그려지면서 한 개의 컴포넌트에 중복 constraint가 생기는 문제 같은데 조금 더 고민을 해봐야 할 것 같습니다...


## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

