### PR TITLE
[Feat] 대학교 이메일 입력 도메인 & 네트워킹

### DIFF
--- a/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
@@ -32,7 +32,6 @@ final class DomainSettingUseCase {
                 case .finished: break
                 }
             } receiveValue: { [weak self] _ in
-                print()
                 guard let self = self else { return }
                 self.isEmailOverlapedSubject.send(false)
             }

--- a/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
@@ -1,0 +1,42 @@
+//
+//  DomainSettingUseCase.swift
+//  App
+//
+//  Created by 김태호 on 2022/11/07.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import Combine
+import Foundation
+import Network
+
+final class DomainSettingUseCase {
+    
+    // output
+    let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    func postUserEmail(email: String, orgnization: Organization) {
+//        guard let authorization = UserDefaults.standard.authToken else { return }
+        let authorization = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ6ZXN0eSIsImlhdCI6MTY2NzE4MDc5MiwiZXhwIjoxNjY4MzkwMzkyLCJzdWIiOiIzNyJ9.jZ35GteW1sM9oz_QQ0cjdxk4p0CSf81Gzv7Kjs_W-zA"
+        let userDTO = SignUpUserDTO(id: orgnization.id, email: email, organizationName: orgnization.name)
+
+        UserAPI.postSignUp(authorization: authorization, userDTO: userDTO)
+            .sink { [weak self] error in
+                guard let self = self else { return }
+                switch error {
+                case .failure(let error):
+                    print(error.localizedString)
+                    self.isEmailOverlapedSubject.send(true)
+                case .finished: break
+                }
+            } receiveValue: { [weak self] _ in
+                print()
+                guard let self = self else { return }
+                self.isEmailOverlapedSubject.send(false)
+            }
+            .store(in: &cancelBag)
+    }
+    
+}

--- a/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
@@ -18,6 +18,7 @@ final class DomainSettingUseCase {
     private var cancelBag = Set<AnyCancellable>()
     
     func postUserEmail(email: String, orgnization: Organization) {
+        // TODO: 키체인으로 변경하기
 //        guard let authorization = UserDefaults.standard.authToken else { return }
         let authorization = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ6ZXN0eSIsImlhdCI6MTY2NzE4MDc5MiwiZXhwIjoxNjY4MzkwMzkyLCJzdWIiOiIzNyJ9.jZ35GteW1sM9oz_QQ0cjdxk4p0CSf81Gzv7Kjs_W-zA"
         let userDTO = SignUpUserDTO(id: orgnization.id, email: email, organizationName: orgnization.name)

--- a/Projects/App/Sources/Domain/User/UserSignupUseCase.swift
+++ b/Projects/App/Sources/Domain/User/UserSignupUseCase.swift
@@ -50,19 +50,4 @@ final class UserSignupUseCase {
             .store(in: &cancelBag)
     }
     
-    func postSignUpUser() {
-        let userDTO = SignUpUserDTO(id: 1, email: "tmdgusya@suwon.ac.kr", organizationName: "수원대학교")
-
-        UserAPI.postSignUp(userDTO: userDTO)
-            .sink { error in
-                switch error {
-                case .failure(let error): print(error.localizedString)
-                case .finished: break
-                }
-            } receiveValue: { response in
-                print(response)
-            }
-            .store(in: &cancelBag)
-    }
-    
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -73,8 +73,8 @@ extension DomainSettingViewController {
             .store(in: &cancelBag)
         
         viewModel.$isInputValid
-            .sink {[weak self] isInputEmpty in
-                self?.arrowButton.setDisabled(isInputEmpty)
+            .sink {[weak self] isInputValid in
+                self?.arrowButton.setDisabled(!isInputValid)
             }
             .store(in: &cancelBag)
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -47,6 +47,11 @@ final class DomainSettingViewController: UIViewController {
         createLayout()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        emailTextField.becomeFirstResponder()
+    }
+    
     // MARK: - Function
     
     @objc func arrowButtonTapped() {

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -17,7 +17,7 @@ final class DomainSettingViewController: UIViewController {
     
     private var cancelBag = Set<AnyCancellable>()
     
-    private let viewModel = DomainSettingViewModel()
+    private let viewModel: DomainSettingViewModel
     
     private let mainTitleView = MainTitleView(title: "학교 이메일을 알려주세요",
                                               subtitle: "학교 인증에 사용돼요.")
@@ -31,6 +31,15 @@ final class DomainSettingViewController: UIViewController {
     
     // MARK: - LifeCycle
     
+    init(organization: Organization = Organization.mockData[0]) {
+        self.viewModel = DomainSettingViewModel(organization: organization)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         bindUI()
@@ -39,6 +48,12 @@ final class DomainSettingViewController: UIViewController {
     }
     
     // MARK: - Function
+    
+    @objc func arrowButtonTapped() {
+        arrowButton.startIndicator()
+        
+        viewModel.postUserEmail()
+    }
     
 }
 
@@ -49,19 +64,33 @@ extension DomainSettingViewController {
     private func bindUI() {
         emailTextField.textDidChangePublisher
             .compactMap { $0.text }
-            .assign(to: \.userEmail, on: viewModel)
+            .assign(to: \.userInput, on: viewModel)
             .store(in: &cancelBag)
         
-        viewModel.$isEmailEmpty
-            .sink {[weak self] isEmailEmpty in
-                self?.arrowButton.setDisabled(isEmailEmpty)
+        viewModel.$isInputValid
+            .sink {[weak self] isInputEmpty in
+                self?.arrowButton.setDisabled(isInputEmpty)
             }
             .store(in: &cancelBag)
         
-        viewModel.$isDuplicateEmail
-            .sink { [weak self] isDuplicateEmail in
+        viewModel.$shouldDisplayWarning
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] shouldDisplayWarning in
                 guard let self = self else { return }
-                self.emailDuplicatedLabel.isHidden = !isDuplicateEmail
+                self.emailDuplicatedLabel.isHidden = !shouldDisplayWarning
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.isEmailOverlapedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEmailOverlaped in
+                guard let self = self else { return }
+                self.arrowButton.stopIndicator()
+                if isEmailOverlaped {
+                    self.arrowButton.setDisabled(true)
+                } else {
+                    self.navigationController?.pushViewController(VerifingCodeViewController(), animated: true)
+                }
             }
             .store(in: &cancelBag)
         
@@ -106,9 +135,11 @@ extension DomainSettingViewController {
         emailTextField.autocapitalizationType = .none
         
         domainPlaceholder.textColor = .white
-        domainPlaceholder.text = "@pos.idserve.net"
+        domainPlaceholder.text = "@\(viewModel.getOrgDomain())"
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
+        
+        arrowButton.addTarget(self, action: #selector(arrowButtonTapped), for: .touchUpInside)
         
         emailDuplicatedLabel.textColor = .red
         emailDuplicatedLabel.text = "이미 사용된 이메일이에요."
@@ -172,17 +203,3 @@ extension DomainSettingViewController {
     }
     
 }
-
-// MARK: - Previews
-
-#if DEBUG
-import SwiftUI
-
-struct DomainSettingViewControllerPreview: PreviewProvider {
-    
-    static var previews: some View {
-        DomainSettingViewController().toPreview()
-    }
-    
-}
-#endif

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -135,7 +135,7 @@ extension DomainSettingViewController {
         emailTextField.autocapitalizationType = .none
         
         domainPlaceholder.textColor = .white
-        domainPlaceholder.text = "@\(viewModel.getOrgDomain())"
+        domainPlaceholder.text = "@\(viewModel.organization.domain)"
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -10,23 +10,58 @@ import Combine
 import Foundation
 
 final class DomainSettingViewModel {
+    
+    // MARK: - Properties
+    
+    private let organization: Organization
+    private let useCase = DomainSettingUseCase()
+    
     // input
-    @Published var userEmail: String = ""
+    @Published var userInput: String = ""
     
     // output
-    @Published var isEmailEmpty = true
-    @Published var isDuplicateEmail = false
-    @Published var isButtonValid = false
-    
-    var orgDomain: String = ""
+    @Published var isInputValid = true
+    @Published var shouldDisplayWarning = false
+    let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     private var cancelBag = Set<AnyCancellable>()
     
-    init() {
-        $userEmail
-            .map(checkEmailValid)
-            .assign(to: \.isEmailEmpty, on: self)
+    init(organization: Organization) {
+        self.organization = organization
+        
+        $userInput
+            .map(checkInputValid)
+            .assign(to: \.isInputValid, on: self)
             .store(in: &cancelBag)
+        
+        $userInput
+            .sink { [weak self] _ in
+                if let self = self, self.shouldDisplayWarning {
+                    self.shouldDisplayWarning = false
+                }
+            }
+            .store(in: &cancelBag)
+        
+        useCase.isEmailOverlapedSubject
+            .sink { [weak self] isEmailOverlaped in
+                guard let self = self else { return }
+                print(#function)
+                if isEmailOverlaped {
+                    self.shouldDisplayWarning = true
+                }
+                self.isEmailOverlapedSubject.send(isEmailOverlaped)
+                
+            }
+            .store(in: &cancelBag)
+    }
+    
+    func getOrgDomain() -> String {
+        return organization.domain
+    }
+    
+    func postUserEmail() {
+        let userEmail: String = userInput + "@" + organization.domain
+        useCase.postUserEmail(email: userEmail, orgnization: organization)
     }
 }
 
@@ -34,8 +69,8 @@ final class DomainSettingViewModel {
 
 extension DomainSettingViewModel {
     
-    private func checkEmailValid(email: String) -> Bool {
-        return email.isEmpty
+    private func checkInputValid(email: String) -> Bool {
+        return email.isEmpty || email.contains(" ")
     }
     
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -20,7 +20,7 @@ final class DomainSettingViewModel {
     @Published var userInput: String = ""
     
     // output
-    @Published var isInputValid = true
+    @Published var isInputValid = false
     @Published var shouldDisplayWarning = false
     let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
@@ -66,7 +66,7 @@ final class DomainSettingViewModel {
 extension DomainSettingViewModel {
     
     private func checkInputValid(email: String) -> Bool {
-        return email.isEmpty || email.contains(" ")
+        return !(email.isEmpty || email.contains(" "))
     }
     
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -13,7 +13,7 @@ final class DomainSettingViewModel {
     
     // MARK: - Properties
     
-    private let organization: Organization
+    let organization: Organization
     private let useCase = DomainSettingUseCase()
     
     // input
@@ -53,10 +53,6 @@ final class DomainSettingViewModel {
                 
             }
             .store(in: &cancelBag)
-    }
-    
-    func getOrgDomain() -> String {
-        return organization.domain
     }
     
     func postUserEmail() {

--- a/Projects/App/Sources/UI/Organization/OrganizationList/View/OrganizationListViewController.swift
+++ b/Projects/App/Sources/UI/Organization/OrganizationList/View/OrganizationListViewController.swift
@@ -103,7 +103,9 @@ extension OrganizationListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let organization = viewModel.searchedOrgArray[indexPath.row]
-        navigationController?.pushViewController(DomainSettingViewController(), animated: true)
+        let domainSettingVC = DomainSettingViewController(organization: organization)
+        
+        navigationController?.pushViewController(domainSettingVC, animated: true)
     }
     
 }

--- a/Projects/Network/Sources/API/UserAPI.swift
+++ b/Projects/Network/Sources/API/UserAPI.swift
@@ -13,12 +13,12 @@ public struct UserAPI {
     
     static let networkService = NetworkService()
 
-    public static func postSignUp(userDTO: SignUpUserDTO) -> AnyPublisher<String, NetworkError> {
-        let header = ["Content-Type": "application/json"]
-        let user = userDTO
+    public static func postSignUp(authorization: String, userDTO: SignUpUserDTO) -> AnyPublisher<Bool, NetworkError> {
+        let header = ["Content-Type": "application/json", "Authorization": "\(authorization)"]
+        let user = ["email": userDTO.email, "organizationName": userDTO.organizationName]
         let endpoint = Endpoint(path: "/api/users", method: .post, bodyParams: user, headers: header)
         
-        return networkService.request(with: endpoint, responseType: String.self)
+        return networkService.request(with: endpoint)
     }
     
     public static func postAccessToken(accessToken: String) -> AnyPublisher<UserOauthDTO, NetworkError> {


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] DomainSettingUseCase 생성 
- [x] DomainSettingUseCase 연결
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="">|<img width="250" src="https://user-images.githubusercontent.com/81206228/200221338-1b74c7de-4361-4322-b546-47d6318d4d42.gif">|

### DomainSettingUseCase 연결
 - 기존 UserSignupUseCase에 있던 postSingupUser를 삭제하였습니다.
 - DomainSettingUseCase를 만들어 postSingupUser를 postUserEmail로 변경하였습니다
 - API문서 그대로 postUserEmail의 경우 user api 영역에 있으므로 UserAPI에 남겨뒀습니다.
   하지만 프론트엔드에서는 domainSetting의 영역이기 때문에 따로 DomainSettingUseCase를 만들어 UserAPI에서 호출하였습니다

###  DomainSettingUseCase 생성 
 - DomainSettingViewController와 DomainSettingUseCase를 연결했습니다
 - DomainSettingViewController와 OrganizationListViewController를 연결했습니다
   pushViewController를 통해 넘어오기 전, DomainSettingViewController의 파라미터 값으로 가지고 있던 Organization을 넘겨주도록 하였습니다

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

## Checklist
- [ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

