### PR TITLE
[Fix] cell 재사용으로 인한 UI bug 수정

### DIFF
--- a/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Cell/PlaceCell.swift
@@ -23,8 +23,6 @@ final class PlaceCell: UICollectionViewCell {
     private lazy var pageControl = UIPageControl()
     private lazy var reviewViews = [ReviewPageView(), ReviewPageView(), ReviewPageView()]
     
-    private lazy var middelView = UIView()
-    private lazy var gradientStackView = UIStackView()
     private lazy var bottomView = UIView()
     
     private lazy var placeNameLabel = UILabel()
@@ -51,6 +49,13 @@ final class PlaceCell: UICollectionViewCell {
         scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
         pageControl.currentPage = 0
         pageControl.numberOfPages = 0
+        
+        reviewViews
+            .filter { $0.superview != nil }
+            .forEach {
+                $0.snp.removeConstraints()
+                $0.removeFromSuperview()
+            }
     }
     
 }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -42,7 +42,13 @@ final class PlaceListViewController: UIViewController {
         configureUI()
         configureHierarchy()
         configureDataSource()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.reset()
         bind()
+        viewModel.initialFetch()
     }
     
     // MARK: - Function

--- a/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/Views/ReviewPageView.swift
@@ -37,7 +37,8 @@ extension ReviewPageView {
     
     func setUp(with review: Review) {
         reviewImageView.load(url: review.imageURL)
-        gradientView.isHidden = review.menuName?.isEmpty ?? true ? true : false
+        let isMenuEmpty = review.menuName?.isEmpty ?? true
+        gradientView.isHidden = isMenuEmpty
         menuLabel.text = review.menuName
     }
     
@@ -66,7 +67,7 @@ extension ReviewPageView {
         
         gradientView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
-            $0.top.equalTo(menuLabel.snp.top).offset(40)
+            $0.top.equalTo(menuLabel.snp.top).offset(-40)
         }
         
         menuLabel.snp.makeConstraints {

--- a/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
@@ -43,7 +43,6 @@ class PlaceListViewModel {
         self.useCase = useCase
         self.placeType = placeType
         bind()
-        initialFetch()
     }
     
 }
@@ -52,7 +51,22 @@ class PlaceListViewModel {
 
 extension PlaceListViewModel: ErrorMapper {
     
-    private func initialFetch() {
+    private func bind() {
+        $placeType
+            .sink { [weak self] type in
+                guard let self = self else { return }
+                
+                switch type {
+                case .whole:
+                    self.result = self.wholePlace.placeList
+                case .hot:
+                    self.result = self.hotPlace.placeList
+                }
+            }
+            .store(in: &self.cancelBag)
+    }
+    
+    func initialFetch() {
         placeType = .hot
         prefetch(at: [1], willUpdate: false)
         placeType = .whole
@@ -98,20 +112,11 @@ extension PlaceListViewModel: ErrorMapper {
             break
         }
     }
-    
-    private func bind() {
-        $placeType
-            .sink { [weak self] type in
-                guard let self = self else { return }
-                
-                switch type {
-                case .whole:
-                    self.result = self.wholePlace.placeList
-                case .hot:
-                    self.result = self.hotPlace.placeList
-                }
-            }
-            .store(in: &self.cancelBag)
-    }
 
+    func reset() {
+        result = []
+        wholePlace = Section(type: .whole)
+        hotPlace = Section(type: .hot)
+    }
+    
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 그라디언트 뷰 안 보이는 현상 수정
- [x] 셀 재사용할 때 다른 맛집 UI 가져오는 현상 수정 by prepareForReuse
- [x] PlaceDetailVC → PlaceListVC 로 다시 넘어갈 때 맛집 데이터 업데이트 되도록 수정

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="">|<img width="250" src="">|-->

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

