### PR TITLE
[Fix] 맛집리스트 header spider man 버그 수정

### DIFF
--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -172,7 +172,7 @@ extension PlaceListViewController {
         snapshot.deleteAllItems()
         snapshot.appendSections([1])
         snapshot.appendItems(items, toSection: 1)
-        dataSource.apply(snapshot)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] animation 제거

|애니메이션 true|애니메이션 false|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/73650994/200520578-f731137c-a41c-47b1-8ad9-538395a788a9.gif">|<img width="250" src="https://user-images.githubusercontent.com/73650994/200520568-1109c36b-fd22-46ae-80de-594284df64b9.gif">|


## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- diffableDatasource 가 데이터의 교체를 제공해주지 않아요,,,, 
데이터를 아예 삭제하고 추가해야해서
새로 추가 : 새로운 헤더다! 하고 슈웅~ 날라가는 버그가 생기게 되었습니다.
디퍼블은 부드러운 UI가 특장점이었는데,,, 일단 버그 없애기 위해 애니메이션을 제거했습니다.

## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

