### PR TITLE
[Feat] profileView 닉네임 표시 및 변경

### DIFF
--- a/Projects/App/Sources/Domain/User/UserNicknameUseCase.swift
+++ b/Projects/App/Sources/Domain/User/UserNicknameUseCase.swift
@@ -1,0 +1,53 @@
+//
+//  UserNicknameUseCase.swift
+//  App
+//
+//  Created by Lee Myeonghwan on 2022/11/08.
+//  Copyright © 2022 com.zesty. All rights reserved.
+//
+
+import Combine
+import Foundation
+import Network
+
+final class UserNicknameUseCase {
+    
+    // output
+    let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
+    let isNickNameChangedSubject = PassthroughSubject<Bool, Never>()
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
+    func getNicknameValidationUser(nickname: String) {
+        UserAPI.getNicknameValidation(nickname: nickname)
+            .sink { [weak self] error in
+                guard let self = self else { return }
+                switch error {
+                case .failure(let error):
+                    print(error.localizedString)
+                    self.isNickNameOverlapedSubject.send(true)
+                case .finished: break
+                }
+            } receiveValue: { _ in
+                self.isNickNameOverlapedSubject.send(false)
+            }
+            .store(in: &cancelBag)
+    }
+    
+    func putNicknameUser(nickname: String) {
+        guard let authorization = KeyChainManager.read(key: .authToken) else { return }
+        UserAPI.putNickname(authorization: authorization, nickname: nickname)
+            .sink { error in
+                switch error {
+                case .failure(let error): print(error.localizedString)
+                case .finished: break
+                }
+            } receiveValue: { [weak self] _ in
+                guard let self = self else { return }
+                UserInfoManager.userInfo?.userNickname = nickname
+                self.isNickNameChangedSubject.send(true)
+            }
+            .store(in: &cancelBag)
+    }
+    
+}

--- a/Projects/App/Sources/Domain/User/UserSignupUseCase.swift
+++ b/Projects/App/Sources/Domain/User/UserSignupUseCase.swift
@@ -12,40 +12,19 @@ import Network
 
 final class UserSignupUseCase {
     
-    // output
-    let isNickNameOverlapedSubject = PassthroughSubject<Bool, Never>()
-    let isNickNameChangedSubject = PassthroughSubject<Bool, Never>()
-    
     private var cancelBag = Set<AnyCancellable>()
     
-    func getNicknameValidationUser(nickname: String) {
-        UserAPI.getNicknameValidation(nickname: nickname)
-            .sink { [weak self] error in
-                guard let self = self else { return }
-                switch error {
-                case .failure(let error):
-                    print(error.localizedString)
-                    self.isNickNameOverlapedSubject.send(true)
-                case .finished: break
-                }
-            } receiveValue: { _ in
-                self.isNickNameOverlapedSubject.send(false)
-            }
-            .store(in: &cancelBag)
-    }
-    
-    func putNicknameUser(nickname: String) {
-        guard let authorization = KeyChainManager.read(key: .authToken) else { return }
-        UserAPI.putNickname(authorization: authorization, nickname: nickname)
+    func postSignUpUser() {
+        let userDTO = SignUpUserDTO(id: 1, email: "tmdgusya@suwon.ac.kr", organizationName: "수원대학교")
+
+        UserAPI.postSignUp(userDTO: userDTO)
             .sink { error in
                 switch error {
                 case .failure(let error): print(error.localizedString)
                 case .finished: break
                 }
-            } receiveValue: { [weak self] _ in
-                guard let self = self else { return }
-                UserInfoManager.userInfo?.userNickname = nickname
-                self.isNickNameChangedSubject.send(true)
+            } receiveValue: { response in
+                print(response)
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/User/Login/View/ThirdPartyLoginViewController.swift
+++ b/Projects/App/Sources/UI/User/Login/View/ThirdPartyLoginViewController.swift
@@ -94,7 +94,7 @@ extension ThirdPartyLoginViewController {
             .sink { [weak self] shouldSetNickname in
                 guard let self = self else { return }
                 if shouldSetNickname {
-                    self.navigationController?.pushViewController(NickNameInputViewController(), animated: true)
+                    self.navigationController?.pushViewController(NickNameInputViewController(state: .signup), animated: true)
                 } else {
                     self.navigationController?.pushViewController(PlaceListViewController(), animated: true)
                 }

--- a/Projects/App/Sources/UI/User/Profile/View/ProfileViewController.swift
+++ b/Projects/App/Sources/UI/User/Profile/View/ProfileViewController.swift
@@ -26,7 +26,7 @@ final class ProfileViewController: UIViewController {
     private let dividerView = UIView()
     private let profileUserMenuStackView = UIStackView()
     
-    private var profileNickNameView = ProfileNickNameView()
+    private lazy var profileNickNameView = ProfileNickNameView(viewModel: viewModel)
     private var profileMenuView1 = ProfileMenuView(menuText: "공지사항")
     private var profileMenuView2 = ProfileMenuView(menuText: "이용약관")
     private var profileMenuView3 = ProfileMenuView(menuText: "제스티를 만든 사람들")
@@ -86,11 +86,18 @@ final class ProfileViewController: UIViewController {
 
 extension ProfileViewController {
     
-    func bindUI() {
+    private func bindUI() {
         viewModel.isUserLoggedOutSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.navigationController?.popToRootViewController(animated: true)
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.changeNickNameButtonClicked
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.navigationController?.pushViewController(NickNameInputViewController(state: .profile, profileViewModel: self?.viewModel), animated: true)
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/User/Profile/View/Views/ProfileNickNameView.swift
+++ b/Projects/App/Sources/UI/User/Profile/View/Views/ProfileNickNameView.swift
@@ -8,20 +8,27 @@
 
 import UIKit
 import SnapKit
+import Combine
 
 final class ProfileNickNameView: UIView {
 
     // MARK: - Properties
     
+    weak var viewModel: ProfileViewModel?
+    
+    private var cancelBag = Set<AnyCancellable>()
+    
     private let changeNickNameButton = UIButton()
-    private let nickNameLabel = UILabel()
+    let nickNameLabel = UILabel()
 
     // MARK: - LifeCycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(viewModel: ProfileViewModel = ProfileViewModel()) {
+        super.init(frame: .zero)
+        self.viewModel = viewModel
         configureUI()
         createLayout()
+        bindUI()
     }
 
     required init?(coder: NSCoder) {
@@ -29,7 +36,25 @@ final class ProfileNickNameView: UIView {
     }
 
     // MARK: - Function
+    
+    @objc private func changeNickNameButtonClicked() {
+        viewModel?.changeNickNameButtonClicked.send(true)
+    }
+    
+}
 
+// MARK: - Bind UI
+extension ProfileNickNameView {
+    
+    private func bindUI() {
+        viewModel?.isNickNameChangedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.nickNameLabel.text = UserInfoManager.userInfo?.userNickname
+            }
+            .store(in: &cancelBag)
+    }
+    
 }
 
 // MARK: - UI Function
@@ -41,11 +66,12 @@ extension ProfileNickNameView {
         changeNickNameButton.setImage(UIImage(systemName: "pencil"), for: .normal)
         changeNickNameButton.tintColor = .black
         changeNickNameButton.backgroundColor = .zestyColor(.background)
+        changeNickNameButton.addTarget(self, action: #selector(changeNickNameButtonClicked), for: .touchUpInside)
 
-        nickNameLabel.text = "6글자제한O"
         nickNameLabel.backgroundColor = .zestyColor(.background)
         nickNameLabel.textColor = .black
         nickNameLabel.font = UIFont.systemFont(ofSize: CGFloat(22), weight: .bold)
+        nickNameLabel.text = viewModel?.userNickname
     }
 
     private func createLayout() {
@@ -66,7 +92,7 @@ extension ProfileNickNameView {
             make.centerY.equalToSuperview()
         }
     }
-
+    
 }
 
 // MARK: - Previews

--- a/Projects/App/Sources/UI/User/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/App/Sources/UI/User/Profile/ViewModel/ProfileViewModel.swift
@@ -11,11 +11,17 @@ import UIKit
 
 final class ProfileViewModel {
     
-    private let useCase = UserProfileUseCase()
+    private let profileUseCase = UserProfileUseCase()
+    private let changeNicknameUseCase = UserNicknameUseCase()
     
     private var cancelBag = Set<AnyCancellable>()
     
+    // output
     let isUserLoggedOutSubject = PassthroughSubject<Bool, Never>()
+    let isNickNameChangedSubject = PassthroughSubject<Bool, Never>()
+    let changeNickNameButtonClicked = PassthroughSubject<Bool, Never>()
+    
+    let userNickname = UserInfoManager.userInfo?.userNickname ?? "unknown"
     
     func userLogout() {
         UserInfoManager.resetUserInfo()
@@ -23,14 +29,20 @@ final class ProfileViewModel {
     }
     
     func userWithdrawl() {
-        useCase.deleteUser()
+        profileUseCase.deleteUser()
         KeyChainManager.delete(key: .authToken)
     }
     
     init() {
-        useCase.isUserDeletedSubject
+        profileUseCase.isUserDeletedSubject
             .sink { [weak self] _ in
                 self?.userLogout()
+            }
+            .store(in: &cancelBag)
+        
+        changeNicknameUseCase.isNickNameChangedSubject
+            .sink { [weak self] _ in
+                self?.isNickNameChangedSubject.send(true)
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/NickNameInputViewController.swift
@@ -11,11 +11,19 @@ import UIKit
 import DesignSystem
 import Firebase
 
+enum NicknameInutViewState {
+    case signup
+    case profile
+}
+
 final class NickNameInputViewController: UIViewController {
     
     // MARK: - Properties
     
+    private let state: NicknameInutViewState
+    
     private let viewModel = NickNameInputViewModel()
+    private weak var profileViewModel: ProfileViewModel?
     
     private let mainTitleView = MainTitleView(title: "닉네임을 알려주세요", subtitle: "언제든지 변경할 수 있어요.")
     private let nickNameTextFieldUIView = UIView()
@@ -28,6 +36,16 @@ final class NickNameInputViewController: UIViewController {
     private var cancelBag = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
+    
+    init(state: NicknameInutViewState, profileViewModel: ProfileViewModel? = nil) {
+        self.state = state
+        self.profileViewModel = profileViewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -118,7 +136,13 @@ extension NickNameInputViewController {
             .sink { [weak self] isNickNameChanged in
                 guard let self = self else { return }
                 if isNickNameChanged {
-                    self.navigationController?.pushViewController(SignupCompleteViewController(), animated: true)
+                    switch self.state {
+                    case .signup:
+                        self.navigationController?.pushViewController(SignupCompleteViewController(), animated: true)
+                    case .profile:
+                        self.profileViewModel?.isNickNameChangedSubject.send(true)
+                        self.navigationController?.popViewController(animated: true)
+                    }
                 }
             }
             .store(in: &cancelBag)
@@ -254,7 +278,7 @@ import SwiftUI
 struct NickNameInputViewTemplatePreview: PreviewProvider {
     
     static var previews: some View {
-        NickNameInputViewController().toPreview()
+        NickNameInputViewController(state: .profile).toPreview()
     }
 
 }

--- a/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
+++ b/Projects/App/Sources/UI/User/Signup/ViewModel/NickNameInputViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 
 final class NickNameInputViewModel {
     
-    private let useCase = UserSignupUseCase()
+    private let useCase = UserNicknameUseCase()
     
     // Input
     @Published var nickNameText = ""


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] profileViewController 에서 닉네임 표시
- [x] profileViewController 과 nicknameViewController 연결

nicknameViewController 와 viewModel의 재사용을 위해 State enum 을 사용하여 분기처리하였습니다.

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

