### PR TITLE
[Fix] 특정 뷰 swipe 금지 처리

### DIFF
--- a/Projects/App/Sources/Global/Extension/UINavigationController+.swift
+++ b/Projects/App/Sources/Global/Extension/UINavigationController+.swift
@@ -16,6 +16,17 @@ extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate 
     }
 
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if viewControllers.last is SwipeForbidden {
+            return false
+        }
         return viewControllers.count > 1
     }
 }
+
+protocol SwipeForbidden {}
+
+extension PlaceListViewController: SwipeForbidden {}
+extension DomainSettingViewController: SwipeForbidden {}
+extension AddPlaceResultViewController: SwipeForbidden {}
+extension ReviewCardViewController: SwipeForbidden {}
+extension SignupCompleteViewController: SwipeForbidden {}

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/DomainSettingCompleteViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/DomainSettingCompleteViewController.swift
@@ -51,7 +51,6 @@ extension DomainSettingCompleteViewController {
         view.backgroundColor = .white
         
         navigationItem.setHidesBackButton(true, animated: true)
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         
         cardView.clipsToBounds = true
         cardView.layer.cornerRadius = 16

--- a/Projects/App/Sources/UI/Place/AddPlace/View/AddPlaceResultViewController.swift
+++ b/Projects/App/Sources/UI/Place/AddPlace/View/AddPlaceResultViewController.swift
@@ -204,7 +204,6 @@ extension AddPlaceResultViewController {
     
     private func configureUI() {
         view.backgroundColor = .white // zestyColor(.backgroundColor)
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
     
     private func createLayout() {

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -216,7 +216,6 @@ extension PlaceListViewController {
         
         navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.isHidden = false
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
     
     private func createLayout() {

--- a/Projects/App/Sources/UI/Review/View/ReviewCardViewController.swift
+++ b/Projects/App/Sources/UI/Review/View/ReviewCardViewController.swift
@@ -106,7 +106,6 @@ extension ReviewCardViewController {
     private func configureUI() {
         view.backgroundColor = .systemBackground
         navigationController?.navigationBar.topItem?.title = ""
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         
         let xmarkConfig = UIImage.SymbolConfiguration(weight: .bold)
         let backImage = UIImage(systemName: "xmark", withConfiguration: xmarkConfig)

--- a/Projects/App/Sources/UI/User/Signup/View/SignupCompleteViewController.swift
+++ b/Projects/App/Sources/UI/User/Signup/View/SignupCompleteViewController.swift
@@ -51,7 +51,6 @@ extension SignupCompleteViewController {
     private func configureUI() {
         view.backgroundColor = .white
         
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         navigationItem.setHidesBackButton(true, animated: false)
 
         backgroundImageView.image = UIImage(.img_signup)


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 특정한 뷰 swipe 금지 처리

아래에 적힌 viewController 들의 swipe gesture를 막아놓았습니다.

PlaceListViewController
DomainSettingViewController
AddPlaceResultViewController
ReviewCardViewController
SignupCompleteViewController

protocol 을 채택하여 한번에 특정 viewController의 swipe를 막았습니다.
또한 관리가 용이하도록 UINavigationController Extension 내부에 금지가 필요한 viewController들의 protocol을 채택하였습니다.

@Lia316 와 함께 오류 처리를 하였습니다.

## Reference
<!-- 참고한 자료를 작성해주세요 -->
고반과 리아의 뇌

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

