### PR TITLE
[Hotfix] 리뷰등록 메뉴명과 사진에 따른 버튼 UI & 맛집리스트 refreshControl

### DIFF
--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -27,6 +27,8 @@ final class PlaceListViewController: UIViewController {
     private var snapshot = Snapshot()
     private let headerType = "section-header-element-kind"
     
+    private let refreshControl = UIRefreshControl()
+    
     private var emptyView = UIView()
     private var emptyImageView = UIImageView()
     private var emptyLabel = UILabel()
@@ -53,9 +55,7 @@ final class PlaceListViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel.reset()
         bind()
-        viewModel.initialFetch()
     }
     
     // MARK: - Function
@@ -90,6 +90,14 @@ extension PlaceListViewController: UICollectionViewDataSourcePrefetching, UIColl
         let placeId = viewModel.result[indexPath.row].id
         let placeDetailViewModel = PlaceDetailViewModel(placeId: placeId)
         show(PlaceDetailViewController(viewModel: placeDetailViewModel), sender: nil)
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if refreshControl.isRefreshing {
+            self.refreshControl.endRefreshing()
+            viewModel.reset()
+            viewModel.initialFetch()
+        }
     }
     
 }
@@ -133,6 +141,7 @@ extension PlaceListViewController {
         collectionView.backgroundColor = .systemBackground
         collectionView.delegate = self
         collectionView.prefetchDataSource = self
+        collectionView.refreshControl = refreshControl
         view.addSubview(collectionView)
     }
 

--- a/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/ViewModel/PlaceListViewModel.swift
@@ -43,6 +43,7 @@ class PlaceListViewModel {
         self.useCase = useCase
         self.placeType = placeType
         bind()
+        initialFetch()
     }
     
 }

--- a/Projects/App/Sources/UI/Review/View/ReviewRegisterViewController.swift
+++ b/Projects/App/Sources/UI/Review/View/ReviewRegisterViewController.swift
@@ -86,6 +86,10 @@ extension ReviewRegisterViewController: UIImagePickerControllerDelegate, UINavig
             menuImageView.image = image
             viewModel.uploadImage(with: image)
             viewModel.isRegisterPossible = false
+
+            menuTextField.isHidden = false
+            underline.isHidden = false
+            registerButton.setButtonState(false)
             registerButton.setTitle("리뷰 등록", for: .normal)
         }
         picker.dismiss(animated: true, completion: nil)
@@ -120,8 +124,8 @@ extension ReviewRegisterViewController: UIImagePickerControllerDelegate, UINavig
         menuTextField.textDidChangePublisher
             .compactMap { $0.text }
             .sink { [weak self] text in
-                let isMenuExist = !text.isEmpty
-                self?.registerButton.setButtonState(isMenuExist)
+                let isTextExist = !text.isEmpty
+                self?.registerButton.setButtonState(isTextExist)
             }
             .store(in: &cancelBag)
     }
@@ -164,6 +168,7 @@ extension ReviewRegisterViewController {
         menuTextField.placeholder = "음식 이름"
         menuTextField.textAlignment = .center
         menuTextField.layer.masksToBounds = true
+        menuTextField.isHidden = true
         
         let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tap)
@@ -171,9 +176,10 @@ extension ReviewRegisterViewController {
         underline.clipsToBounds = true
         underline.layer.cornerRadius = 1
         underline.backgroundColor = .black
+        underline.isHidden = true
         
         registerButton.setTitle("사진 없이 리뷰 등록", for: .normal)
-        registerButton.setButtonState(false)
+        registerButton.setButtonState(true)
         registerButton.addTarget(self, action: #selector(registerButtonTouched), for: .touchUpInside)
     }
     
@@ -304,6 +310,7 @@ struct ReviewRegisterPreview: PreviewProvider {
     
     static var previews: some View {
         UINavigationController(rootViewController: ReviewRegisterViewController(viewModel: ReviewRegisterViewModel(placeId: 0, placeName: "요기쿠시동"))).toPreview()
+            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
     }
     
 }


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 리뷰등록 메뉴명과 사진에 따른 버튼 UI 수정
- [x] 맛집리스트 refreshControl 변경

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|리뷰 등록 버튼 UI|맛집리스트 Refresh Control 추가|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/73650994/200776714-b6023939-3988-4bcc-8c17-0ca2125604cb.gif">|<img width="250" src="https://user-images.githubusercontent.com/73650994/200778476-6f89105c-b3f5-457a-afc1-4b803a3e171d.gif">|


## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

