### PR TITLE
[Fix] 서버 API 이슈에 따른 대학교 이메일 인증 로직 변경 & 타이머 시간 멈춤 기능 추가

### DIFF
--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -5,12 +5,15 @@
 //  Created by Lee Myeonghwan on 2022/10/05.
 //
 
+import Combine
 import UIKit
 import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
+    private var now: Date?
+    static let timeIntervalSubject = PassthroughSubject <Int, Never>()
     
     func scene(
         _ scene: UIScene,
@@ -42,6 +45,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 _ = AuthController.handleOpenUrl(url: url)
             }
         }
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        now = Date()
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let now = self.now else { return }
+        let timeInterval = Date().timeIntervalSince(now)
+        SceneDelegate.timeIntervalSubject.send(Int(timeInterval))
     }
     
 }

--- a/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
@@ -14,28 +14,26 @@ final class DomainSettingUseCase {
     
     // output
     let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
+    let isCodeSendSubject = PassthroughSubject<Bool, Never>()
     
     private var cancelBag = Set<AnyCancellable>()
     
-    func postUserEmail(email: String, orgnization: Organization) {
-        guard let authorization = KeyChainManager.read(key: .authToken) else { return }
-        
-        let userDTO = SignUpUserDTO(id: orgnization.id, email: email, organizationName: orgnization.name)
-
-        UserAPI.postSignUp(authorization: authorization, userDTO: userDTO)
+    func sendCode(email: String) {
+        UserAPI.postSendCode(email: email)
             .sink { [weak self] error in
                 guard let self = self else { return }
                 switch error {
                 case .failure(let error):
                     print(error.localizedString)
-                    self.isEmailOverlapedSubject.send(true)
+                    self.isCodeSendSubject.send(false)
                 case .finished: break
                 }
             } receiveValue: { [weak self] _ in
                 guard let self = self else { return }
-                self.isEmailOverlapedSubject.send(false)
+                self.isCodeSendSubject.send(true)
             }
             .store(in: &cancelBag)
+
     }
     
 }

--- a/Projects/App/Sources/Domain/Organization/VerifingCodeUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/VerifingCodeUseCase.swift
@@ -21,7 +21,6 @@ final class VerifingCodeUseCase {
     func postOTPCode(email: String, code: String, organization: Organization) {
         let codeDTO = VerifyCodeDTO(id: organization.id, email: email, code: code)
         
-        print("codeDTO: \(codeDTO)")
         UserAPI.postVerifyCode(codeDTO: codeDTO)
             .sink { [weak self] error in
                 guard let self = self else { return }

--- a/Projects/App/Sources/Domain/Organization/VerifingCodeUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/VerifingCodeUseCase.swift
@@ -14,12 +14,14 @@ final class VerifingCodeUseCase {
     
     // output
     let isCodeValidSubject = PassthroughSubject<Bool, Never>()
+    let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     private var cancelBag = Set<AnyCancellable>()
     
     func postOTPCode(email: String, code: String, organization: Organization) {
         let codeDTO = VerifyCodeDTO(id: organization.id, email: email, code: code)
         
+        print("codeDTO: \(codeDTO)")
         UserAPI.postVerifyCode(codeDTO: codeDTO)
             .sink { [weak self] error in
                 guard let self = self else { return }
@@ -32,6 +34,27 @@ final class VerifingCodeUseCase {
             } receiveValue: {[weak self] _ in
                 guard let self = self else { return }
                 self.isCodeValidSubject.send(true)
+            }
+            .store(in: &cancelBag)
+    }
+    
+    func postSignUp(email: String, orgnization: Organization) {
+        guard let authorization = KeyChainManager.read(key: .authToken) else { return }
+        
+        let userDTO = SignUpUserDTO(id: orgnization.id, email: email, organizationName: orgnization.name)
+
+        UserAPI.postSignUp(authorization: authorization, userDTO: userDTO)
+            .sink { [weak self] error in
+                guard let self = self else { return }
+                switch error {
+                case .failure(let error):
+                    print(error.localizedString)
+                    self.isEmailOverlapedSubject.send(true)
+                case .finished: break
+                }
+            } receiveValue: { [weak self] _ in
+                guard let self = self else { return }
+                self.isEmailOverlapedSubject.send(false)
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -58,7 +58,8 @@ final class DomainSettingViewController: UIViewController {
     
     @objc func arrowButtonTapped() {
         arrowButton.startIndicator()
-        viewModel.postUserEmail()
+        // TODO: 서버 API가 나오면 로직이 바뀔 부분입니다
+        viewModel.sendCode()
     }
     
     private func analytics() {
@@ -93,18 +94,18 @@ extension DomainSettingViewController {
             }
             .store(in: &cancelBag)
         
-        viewModel.isEmailOverlapedSubject
+        viewModel.isCodeSendSubject
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isEmailOverlaped in
+            .sink { [weak self] isCodeSend in
                 guard let self = self else { return }
                 self.arrowButton.stopIndicator()
-                if isEmailOverlaped {
-                    self.arrowButton.setDisabled(true)
-                } else {
+                if isCodeSend {
                     let userEmail = self.viewModel.getUserEmail()
                     let verifingCodeVC = VerifingCodeViewController(organization: self.viewModel.organization,
                                                                     userEmail: userEmail)
                     self.navigationController?.pushViewController(verifingCodeVC, animated: true)
+                } else {
+                    self.arrowButton.setDisabled(true)
                 }
             }
             .store(in: &cancelBag)
@@ -150,7 +151,9 @@ extension DomainSettingViewController {
         emailTextField.autocapitalizationType = .none
         
         domainPlaceholder.textColor = .white
-        domainPlaceholder.text = "@\(viewModel.organization.domain)"
+        // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
+//        domainPlaceholder.text = "@\(viewModel.organization.domain)"
+        domainPlaceholder.text = "@pos.idserve.net"
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -23,6 +23,7 @@ final class DomainSettingViewModel {
     @Published var isInputValid = false
     @Published var shouldDisplayWarning = false
     let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
+    let isCodeSendSubject = PassthroughSubject<Bool, Never>()
     
     private var cancelBag = Set<AnyCancellable>()
     
@@ -33,14 +34,16 @@ final class DomainSettingViewModel {
         bind()
     }
     
-    func postUserEmail() {
+    func sendCode() {
         let userEmail = getUserEmail()
-        useCase.postUserEmail(email: userEmail, orgnization: organization)
+        useCase.sendCode(email: userEmail)
     }
     
     func getUserEmail() -> String {
-        let userEamil: String = userInput + "@" + organization.domain
-        return userEamil
+//        let userEmail: String = userInput + "@" + organization.domain
+        // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
+        let userEmail: String = userInput + "@pos.idserve.net"
+        return userEmail
     }
 }
 
@@ -62,6 +65,7 @@ extension DomainSettingViewModel {
             }
             .store(in: &cancelBag)
         
+        // TODO: 서버의 API가 정리되어 있지 않아서 남겨둡니다. 추후에 이메일 중복 API가 만들어진다면 사용할 예정입니다
         useCase.isEmailOverlapedSubject
             .sink { [weak self] isEmailOverlaped in
                 guard let self = self else { return }
@@ -72,6 +76,20 @@ extension DomainSettingViewModel {
                 
             }
             .store(in: &cancelBag)
+        
+        useCase.isCodeSendSubject
+            .sink { [weak self] isCodeSend in
+                guard let self = self else { return }
+                if isCodeSend {
+                    self.isCodeSendSubject.send(isCodeSend)
+                } else {
+                    // TODO: 나중에 API가 수정되면 변경할 부분입니다
+                    self.shouldDisplayWarning = true
+                }
+                
+            }
+            .store(in: &cancelBag)
+
     }
     
 }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -144,9 +144,21 @@ extension VerifingCodeViewController {
                 guard let self = self else { return }
                 self.arrowButton.isHidden = true
                 if isCodeValid {
-                    self.navigationController?.pushViewController(DomainSettingCompleteViewController(), animated: true)
+                    self.viewModel.postSignUp()
                 } else {
                     self.otpStackView.resetOTP()
+                }
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.isEmailOverlapedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEmailOverlaped in
+                guard let self = self else { return }
+                if isEmailOverlaped {
+                    self.otpStackView.resetOTP()
+                } else {
+                    self.navigationController?.pushViewController(DomainSettingCompleteViewController(), animated: true)
                 }
             }
             .store(in: &cancelBag)
@@ -169,7 +181,9 @@ extension VerifingCodeViewController {
                 }
                 if otpText.count == 4 {
                     self.arrowButton.isHidden = false
-                    self.viewModel.postOTPCode(code: otpText)
+                    // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
+//                    self.viewModel.postOTPCode(code: otpText)
+                    self.viewModel.postSignUp()
                 }
             }
             .store(in: &cancelBag)

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -72,6 +72,16 @@ extension VerifingCodeViewModel {
                 self.isEmailOverlapedSubject.send(isEmailOverlaped)
             }
             .store(in: &cancelBag)
+        
+        SceneDelegate.timeIntervalSubject
+            .sink { [weak self] timeInterval in
+                guard let self = self else { return }
+                self.timerNumber -= timeInterval
+                let minutes = self.timerNumber/60
+                let seconds = self.timerNumber % 60
+                self.timerText = String(format: "%02d:%02d", minutes, seconds)
+            }
+            .store(in: &cancelBag)
     }
     
 }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -18,7 +18,7 @@ final class VerifingCodeViewModel {
     private let useCase = VerifingCodeUseCase()
     private let domainSettingUseCase = DomainSettingUseCase()
     private var timer: Timer?
-    private var timerNumber: Int = 180
+    private var timerNumber: Int = 10
     private let oneMinuteToSecond: Int = 60
     
     // input
@@ -77,9 +77,15 @@ extension VerifingCodeViewModel {
             .sink { [weak self] timeInterval in
                 guard let self = self else { return }
                 self.timerNumber -= timeInterval
-                let minutes = self.timerNumber/60
-                let seconds = self.timerNumber % 60
-                self.timerText = String(format: "%02d:%02d", minutes, seconds)
+                if self.timerNumber < 0 {
+                    self.timerNumber = 0
+                    self.timerText = "인증시간 초과"
+                    self.timer?.invalidate()
+                } else {
+                    let minutes = self.timerNumber/60
+                    let seconds = self.timerNumber % 60
+                    self.timerText = String(format: "%02d:%02d", minutes, seconds)
+                }
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -28,6 +28,7 @@ final class VerifingCodeViewModel {
     @Published var timerText = "03:00"
     @Published var shouldDisplayWarning: Bool = false
     let isCodeValidSubject = PassthroughSubject<Bool, Never>()
+    let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
     private var cancelBag = Set<AnyCancellable>()
     
@@ -52,13 +53,23 @@ extension VerifingCodeViewModel {
                 guard let self = self else { return }
                 if !isCodeValid {
                     self.shouldDisplayWarning = true
+                }
+                self.isCodeValidSubject.send(isCodeValid)
+            }
+            .store(in: &cancelBag)
+        
+        useCase.isEmailOverlapedSubject
+            .sink { [weak self] isEmailOverlaped in
+                guard let self = self else { return }
+                if isEmailOverlaped {
+                    self.shouldDisplayWarning = true
                 } else {
                     let orgID = self.organization.id
                     let orgName = self.organization.name
                     UserInfoManager.userInfo?.userOrgName = orgName
                     UserInfoManager.userInfo?.userOrganization = orgID
                 }
-                self.isCodeValidSubject.send(isCodeValid)
+                self.isEmailOverlapedSubject.send(isEmailOverlaped)
             }
             .store(in: &cancelBag)
     }
@@ -95,10 +106,15 @@ extension VerifingCodeViewModel {
     }
     
     func postOTPCode(code: String) {
+        print("viewmodel userEmail: \(userEmail)")
         useCase.postOTPCode(email: userEmail, code: code, organization: organization)
     }
     
+    func postSignUp() {
+        useCase.postSignUp(email: userEmail, orgnization: organization)
+    }
+    
     func resendEamil() {
-        domainSettingUseCase.postUserEmail(email: self.userEmail, orgnization: self.organization)
+        domainSettingUseCase.sendCode(email: self.userEmail)
     }
 }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -18,7 +18,7 @@ final class VerifingCodeViewModel {
     private let useCase = VerifingCodeUseCase()
     private let domainSettingUseCase = DomainSettingUseCase()
     private var timer: Timer?
-    private var timerNumber: Int = 10
+    private var timerNumber: Int = 180
     private let oneMinuteToSecond: Int = 60
     
     // input

--- a/Projects/Network/Sources/API/UserAPI.swift
+++ b/Projects/Network/Sources/API/UserAPI.swift
@@ -67,6 +67,14 @@ public struct UserAPI {
         let endpoint = Endpoint(path: "/api/users/verify", method: .post, bodyParams: code, headers: header)
         return networkService.request(with: endpoint)
     }
+    
+    public static func postSendCode(email: String) -> AnyPublisher<Bool, NetworkError> {
+        let header = ["Content-Type": "application/json"]
+        let endpoint = Endpoint(path: "/api/users/send/verifyCode", method: .post, bodyParams: ["email": email], headers: header)
+        
+        return networkService.request(with: endpoint)
+    }
+    
 
     public static func deleteUser(authorization: String) -> AnyPublisher<Bool, NetworkError> {
         let header = ["Content-Type": "application/json", "Authorization": "\(authorization)"]


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 대학교 이메일 인증 로직을 변경했습니다
- [x] 타이머가 백그라운드로 갈 경우 

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="">|<img width="250" src="https://user-images.githubusercontent.com/81206228/201112444-14d02704-440a-40ac-86ed-894948752459.gif">|



## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

### 대학교 인증 로직 변경 9c7408394e954eaafdea6b7f699063b1e2867e71

 현재 서버의 API가 제대로 동작하고 있지 않아서 회원가입이 되지 않습니다
 2022.11.10 앱 배포를 위해 대학교 이메일 인증 로직을 일시적으로 수정합니다.

 API 변경 전
 1. 대학교 이메일 입력 뷰에서 요청을 보낸 경우 서버에서 유저 DB에 저장 후 인증 코드 발송
 2. 인증 코드 입력 뷰에서 유저가 4자리의 OTP를 전부 입력할 경우 서버로 코드와 이메일을 POST 요청
    서버에서는 OTP 코드의 유효성을 검사하고 코드의 유효성에 대한 응답을 전달

 - 여기서 발생한 문제
     - 대학교 이메일 입력 뷰에서 이메일 발송을 요청하고 인증 코드 입력 뷰로 넘어간 뒤
        다시 대학교 이메일 입력 뷰로 돌아올 경우 유저 DB에 이메일이 저장이 되어서 이메일을 다시 보낼 수 없다
      - 따라서 인증 메일을 다시 보내는 기능도 동작하지 않습니다.
 - 이 부분에 대한 수정을 요청한 결과
     - 1번 과정에서 1개로 합쳐져 있던 이메일 중복 인증 + 이메일 가입 + 메일 전송 로직이 메일 전송, 이메일 중복 인증 + 이메일 가입 2가지로 변경
     - 이 과정에서 이메일 중복 인증 + 이메일 가입 로직의 위치를 인증 코드의 유효성 검사가 끝난 이후로 변경한 결과
        OTP 코드의 유효성을 검사하는 과정에서 "해당하는 이메일의 유저가 존재하지 않습니다"라는 에러메세지를 반환하는 것을 확인,
     - 서버 내부의 OTP 코드의 유효성 검사의 로직에도 이메일 중복을 확인하는 코드가 있는 것으로 추측이 됩니다.
 - 그 결과, 서버에서 대학교 인증 로직을 변경하지 않는 이상 프론트의 로직과 디자인이 변경되어야 하는 상황이 되었습니다.
 - 또한 올바르지 않은 UX가 발생하는 것(이메일에 대한 유효성 확인이 이메일을 입력하는 곳이 아닌 코드 인증에서 일어남)을 우려하여
   타겟 유저를 한 집단으로 한정하고 인증 코드 부분을 일시적으로 무효화 시키기로 하였습니다.
 - 현재는 어떤 대학교를 들어가던 한 조직의 도메인만 나오게 하였고 어떤 인증 코드를 입력하던 회원가입이 되도록 하였습니다.

 API 변경 후
  1. 대학교 이메일 입력 뷰에서 서버로 이메일 전송 요청
  2. 인증 코드 입력 뷰에서 유저가 4자리의 OTP를 입력할 경우 이메일과 조직 ID 전송 - 제대로 된 인증 없이 가입 중복

 서버의 API 로직이 변경된다면 후에 리팩토링이 시급한 부분입니다.

### 타이머가 백그라운드로 가면 멈추는 버그 9c9f870f9488062b125ce88b26da60749fb9186f
 - SceneDelegate에서 앱이 백그라운드로 내려갈 때의 시간을 저장합니다
 - 다시 앱에 들어올 경우의 시간과 저장한 시간의 차이를 구해서 VerifingCodeViewModel에서 시간 차이를 계산해 타이머의 시간에서 빼줍니다

## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

