### PR TITLE
[Fix] 장소상세 - 사진없는 리뷰 필터링

### DIFF
--- a/Projects/App/Sources/UI/Place/PlaceDetail/ViewModel/PlaceDetailViewModel.swift
+++ b/Projects/App/Sources/UI/Place/PlaceDetail/ViewModel/PlaceDetailViewModel.swift
@@ -74,8 +74,9 @@ class PlaceDetailViewModel {
                     self?.output.send(.fetchReviewListFail(error: error))
                 }
             } receiveValue: { [weak self] reviews in
-                self?.reviews = reviews
-                self?.output.send(.fetchReviewListSucceed(list: reviews))
+                let filtered = reviews.filter { $0.imageURL != nil }
+                self?.reviews = filtered
+                self?.output.send(.fetchReviewListSucceed(list: filtered))
             }
             .store(in: &cancelBag)
     }

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -122,7 +122,7 @@ extension PlaceListViewController: QuestionButtonTapDelegate, UIAdaptivePresenta
         questionPopover.modalPresentationStyle = .popover
         questionPopover.preferredContentSize.height = 70
         questionPopover.popoverPresentationController?.popoverLayoutMargins = UIEdgeInsets(top: 100, left: 200, bottom: 0, right: 20)
-        questionPopover.popoverPresentationController?.permittedArrowDirections = []
+        questionPopover.popoverPresentationController?.permittedArrowDirections = [.up]
         questionPopover.popoverPresentationController?.delegate = self
 
         questionPopover.popoverPresentationController?.sourceRect = sourceView.bounds

--- a/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
+++ b/Projects/App/Sources/UI/Place/PlaceList/View/PlaceListViewController.swift
@@ -122,7 +122,7 @@ extension PlaceListViewController: QuestionButtonTapDelegate, UIAdaptivePresenta
         questionPopover.modalPresentationStyle = .popover
         questionPopover.preferredContentSize.height = 70
         questionPopover.popoverPresentationController?.popoverLayoutMargins = UIEdgeInsets(top: 100, left: 200, bottom: 0, right: 20)
-        questionPopover.popoverPresentationController?.permittedArrowDirections = [.up]
+        questionPopover.popoverPresentationController?.permittedArrowDirections = []
         questionPopover.popoverPresentationController?.delegate = self
 
         questionPopover.popoverPresentationController?.sourceRect = sourceView.bounds


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 장소상세페이지에서 사진 없는 리뷰를 필터링했습니다

현재 서버 API 지연으로 인하여, 서버의존도를 최대한 낮추는게 좋을 것 같아 클라쪽에서 긴급하게 해결을 해보았습니다
기존에는 사진이 없더라고 셀이 표시되어 ux 가 굉장히 떨어져서 긴급 필터링해두었습니다

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/63157395/201134631-e44525cf-5bfa-4421-9a52-1b7c3d9bfa32.png">|<img width="250" src="https://user-images.githubusercontent.com/63157395/201134663-330a27a7-7d25-4c0a-acff-74e901bd96c9.png">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

- 방대한 양의 review 가 등록될 경우를 대비하여 기존 API 계획대로 서버 개발자님 일정 나오는 대로 서버쪽 API 를 손보는 방향으로 수정하는 게 좋을 것 같습니다

## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

