### PR TITLE
[Hotfix] 대학교 이메일 입력 뷰에 이메일 중복 검사 추가

### DIFF
--- a/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
+++ b/Projects/App/Sources/Domain/Organization/DomainSettingUseCase.swift
@@ -36,4 +36,20 @@ final class DomainSettingUseCase {
 
     }
     
+    func getEamilValidation(email: String) {
+        UserAPI.getEamilValidation(email: email)
+            .sink { [weak self] error in
+                guard let self = self else { return }
+                switch error {
+                case .failure(let error):
+                    print(error.localizedString)
+                    self.isEmailOverlapedSubject.send(true)
+                case .finished: break
+                }
+            } receiveValue: { _ in
+                self.isEmailOverlapedSubject.send(false)
+            }
+            .store(in: &cancelBag)
+    }
+    
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -151,9 +151,7 @@ extension DomainSettingViewController {
         emailTextField.autocapitalizationType = .none
         
         domainPlaceholder.textColor = .white
-        // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
-//        domainPlaceholder.text = "@\(viewModel.organization.domain)"
-        domainPlaceholder.text = "@pos.idserve.net"
+        domainPlaceholder.text = "@\(viewModel.organization.domain)"
         domainPlaceholder.font = .systemFont(ofSize: 17, weight: .medium)
         domainPlaceholder.setContentCompressionResistancePriority(.init(1000), for: .horizontal)
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -58,8 +58,7 @@ final class DomainSettingViewController: UIViewController {
     
     @objc func arrowButtonTapped() {
         arrowButton.startIndicator()
-        // TODO: 서버 API가 나오면 로직이 바뀔 부분입니다
-        viewModel.sendCode()
+        viewModel.checkEmailOverlaped()
     }
     
     private func analytics() {
@@ -91,6 +90,20 @@ extension DomainSettingViewController {
             .sink { [weak self] shouldDisplayWarning in
                 guard let self = self else { return }
                 self.emailDuplicatedLabel.isHidden = !shouldDisplayWarning
+            }
+            .store(in: &cancelBag)
+        
+        viewModel.isEmailOverlapedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEmailOverlaped in
+                guard let self = self else { return }
+                self.arrowButton.stopIndicator()
+                if isEmailOverlaped {
+                    self.viewModel.shouldDisplayWarning = true
+                    self.arrowButton.setDisabled(true)
+                } else {
+                    self.viewModel.sendCode()
+                }
             }
             .store(in: &cancelBag)
         

--- a/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/View/DomainSettingViewController.swift
@@ -30,6 +30,8 @@ final class DomainSettingViewController: UIViewController {
     private let domainPlaceholder = UILabel()
     private let arrowButton = ArrowButton(initialDisable: true)
     
+    private let testEamil = "testzesty1234"
+    
     // MARK: - LifeCycle
     
     init(organization: Organization = Organization.mockData[0]) {
@@ -58,7 +60,11 @@ final class DomainSettingViewController: UIViewController {
     
     @objc func arrowButtonTapped() {
         arrowButton.startIndicator()
-        viewModel.checkEmailOverlaped()
+        if emailTextField.text == testEamil {
+            testCodePost()
+        } else {
+            viewModel.checkEmailOverlaped()
+        }
     }
     
     private func analytics() {
@@ -67,6 +73,13 @@ final class DomainSettingViewController: UIViewController {
         ])
     }
     
+    private func testCodePost() {
+        let orgID = viewModel.organization.id
+        let orgName = viewModel.organization.name
+        UserInfoManager.userInfo?.userOrgName = orgName
+        UserInfoManager.userInfo?.userOrganization = orgID
+        navigationController?.pushViewController(DomainSettingCompleteViewController(), animated: true)
+    }
 }
 
 // MARK: - Bind Function

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -40,9 +40,7 @@ final class DomainSettingViewModel {
     }
     
     func getUserEmail() -> String {
-//        let userEmail: String = userInput + "@" + organization.domain
-        // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
-        let userEmail: String = userInput + "@pos.idserve.net"
+        let userEmail: String = userInput + "@" + organization.domain
         return userEmail
     }
 }

--- a/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/DomainSetting/ViewModel/DomainSettingViewModel.swift
@@ -39,6 +39,11 @@ final class DomainSettingViewModel {
         useCase.sendCode(email: userEmail)
     }
     
+    func checkEmailOverlaped() {
+        let userEmail = getUserEmail()
+        useCase.getEamilValidation(email: userEmail)
+    }
+    
     func getUserEmail() -> String {
         let userEmail: String = userInput + "@" + organization.domain
         return userEmail
@@ -63,7 +68,6 @@ extension DomainSettingViewModel {
             }
             .store(in: &cancelBag)
         
-        // TODO: 서버의 API가 정리되어 있지 않아서 남겨둡니다. 추후에 이메일 중복 API가 만들어진다면 사용할 예정입니다
         useCase.isEmailOverlapedSubject
             .sink { [weak self] isEmailOverlaped in
                 guard let self = self else { return }
@@ -80,11 +84,7 @@ extension DomainSettingViewModel {
                 guard let self = self else { return }
                 if isCodeSend {
                     self.isCodeSendSubject.send(isCodeSend)
-                } else {
-                    // TODO: 나중에 API가 수정되면 변경할 부분입니다
-                    self.shouldDisplayWarning = true
                 }
-                
             }
             .store(in: &cancelBag)
 

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -60,6 +60,7 @@ final class VerifingCodeViewController: UIViewController {
     @objc func resendButtonTapped() {
         viewModel.resetTimer()
         showToastMessage()
+        viewModel.shouldDisplayWarning = false
         viewModel.resendEamil()
         viewModel.startTimer()
         
@@ -165,17 +166,11 @@ extension VerifingCodeViewController {
             }
             .store(in: &cancelBag)
         
-        viewModel.displayWarningSubject
+        viewModel.$shouldDisplayWarning
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] displayWarningType in
+            .sink { [weak self] shouldDisplayWarning in
                 guard let self = self else { return }
-                switch displayWarningType {
-                case .codeWarning:
-                    self.warningMessage.text = "잘못된 코드예요."
-                case .emailWarning:
-                    self.warningMessage.text = "이미 사용된 이메일이에요."
-                }
-                self.warningMessage.isHidden = false
+                self.warningMessage.isHidden = !shouldDisplayWarning
             }
             .store(in: &cancelBag)
         

--- a/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/View/VerifingCodeViewController.swift
@@ -181,9 +181,7 @@ extension VerifingCodeViewController {
                 }
                 if otpText.count == 4 {
                     self.arrowButton.isHidden = false
-                    // TODO: 현재는 pos.idserve.net으로 고정하고 나중에 API가 수정되면 변경할 부분입니다
-//                    self.viewModel.postOTPCode(code: otpText)
-                    self.viewModel.postSignUp()
+                    self.viewModel.postOTPCode(code: otpText)
                 }
             }
             .store(in: &cancelBag)

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -23,10 +23,10 @@ final class VerifingCodeViewModel {
     
     // input
     @Published var userInputCode: String = ""
+    @Published var shouldDisplayWarning: Bool = false
     
     // output
     @Published var timerText = "03:00"
-    let displayWarningSubject = PassthroughSubject<WarningMessageType, Never>()
     let isCodeValidSubject = PassthroughSubject<Bool, Never>()
     let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
@@ -52,7 +52,7 @@ extension VerifingCodeViewModel {
             .sink { [weak self] isCodeValid in
                 guard let self = self else { return }
                 if !isCodeValid {
-                    self.displayWarningSubject.send(.codeWarning)
+                    self.shouldDisplayWarning = true
                 }
                 self.isCodeValidSubject.send(isCodeValid)
             }
@@ -62,7 +62,7 @@ extension VerifingCodeViewModel {
             .sink { [weak self] isEmailOverlaped in
                 guard let self = self else { return }
                 if isEmailOverlaped {
-                    self.displayWarningSubject.send(.emailWarning)
+                    self.shouldDisplayWarning = true
                 } else {
                     let orgID = self.organization.id
                     let orgName = self.organization.name
@@ -133,13 +133,4 @@ extension VerifingCodeViewModel {
     func resendEamil() {
         domainSettingUseCase.sendCode(email: self.userEmail)
     }
-}
-
-extension VerifingCodeViewModel {
-    
-    enum WarningMessageType {
-        case codeWarning
-        case emailWarning
-    }
-    
 }

--- a/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
+++ b/Projects/App/Sources/UI/Organization/VerifyCode/ViewModel/VerifingCodeViewModel.swift
@@ -26,7 +26,7 @@ final class VerifingCodeViewModel {
     
     // output
     @Published var timerText = "03:00"
-    @Published var shouldDisplayWarning: Bool = false
+    let displayWarningSubject = PassthroughSubject<WarningMessageType, Never>()
     let isCodeValidSubject = PassthroughSubject<Bool, Never>()
     let isEmailOverlapedSubject = PassthroughSubject<Bool, Never>()
     
@@ -52,7 +52,7 @@ extension VerifingCodeViewModel {
             .sink { [weak self] isCodeValid in
                 guard let self = self else { return }
                 if !isCodeValid {
-                    self.shouldDisplayWarning = true
+                    self.displayWarningSubject.send(.codeWarning)
                 }
                 self.isCodeValidSubject.send(isCodeValid)
             }
@@ -62,7 +62,7 @@ extension VerifingCodeViewModel {
             .sink { [weak self] isEmailOverlaped in
                 guard let self = self else { return }
                 if isEmailOverlaped {
-                    self.shouldDisplayWarning = true
+                    self.displayWarningSubject.send(.emailWarning)
                 } else {
                     let orgID = self.organization.id
                     let orgName = self.organization.name
@@ -133,4 +133,13 @@ extension VerifingCodeViewModel {
     func resendEamil() {
         domainSettingUseCase.sendCode(email: self.userEmail)
     }
+}
+
+extension VerifingCodeViewModel {
+    
+    enum WarningMessageType {
+        case codeWarning
+        case emailWarning
+    }
+    
 }

--- a/Projects/Network/Sources/API/UserAPI.swift
+++ b/Projects/Network/Sources/API/UserAPI.swift
@@ -55,6 +55,12 @@ public struct UserAPI {
         return networkService.request(with: endpoint)
     }
     
+    public static func getEamilValidation(email: String) -> AnyPublisher<Bool, NetworkError> {
+        let header = ["Content-Type": "application/json"]
+        let endpoint = Endpoint(path: "/api/users/validate/email", method: .get, queryParams: ["email": email], headers: header)
+        return networkService.request(with: endpoint)
+    }
+    
     public static func putNickname(authorization: String, nickname: String) -> AnyPublisher<Bool, NetworkError> {
         let header = ["Content-Type": "application/json", "Authorization": "\(authorization)"]
         let endpoint = Endpoint(path: "/api/users/nickname", method: .put, bodyParams: ["nickname": nickname], headers: header)
@@ -75,7 +81,6 @@ public struct UserAPI {
         return networkService.request(with: endpoint)
     }
     
-
     public static func deleteUser(authorization: String) -> AnyPublisher<Bool, NetworkError> {
         let header = ["Content-Type": "application/json", "Authorization": "\(authorization)"]
         let endpoint = Endpoint(path: "/api/users", method: .delete, headers: header)


### PR DESCRIPTION
## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 대학교 이메일 입력 뷰에 이메일 중복 검사 추가
- [x] 인증코드 유효성 검사 복구

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="">|<img width="250" src="https://user-images.githubusercontent.com/81206228/201253670-eb0084ee-aa5c-4abe-926d-2b81240627d3.gif">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
### 대학교 이메일 입력 뷰에 이메일 중복 검사 추가
기존에 문제가 되었던 인증 코드 API의 문제가 해결됨에 따라 네트워킹 로직을 변경하였습니다.
   - 문제가 아예 해결된 것은 아닙니다.
   - 코드 인증 API에서 유저 이메일 중복 검사하던 기능이 삭제 되었습니다.

 1. 대학교에 따라 도메인이 자동으로 수정되도록 변경하였습니다.
 2. 코드 인증 로직이 정상적으로 작동하도록 수정하였습니다.
 3. 대학교 입력 뷰에서 이메일 중복 검사가 되도록 변경하였습니다.


## Reference
<!-- 참고한 자료를 작성해주세요 -->

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 13
  - [x] iPhone 13 Pro Max

